### PR TITLE
chore: use types `OpenAIFunctions`

### DIFF
--- a/packages/agent-utils/src/agent/basicFunctionCallLoop.ts
+++ b/packages/agent-utils/src/agent/basicFunctionCallLoop.ts
@@ -26,7 +26,8 @@ export async function* basicFunctionCallLoop<TContext extends { llm: LlmApi, cha
   while (true) {
     await chat.fitToContextWindow();
 
-    const response = await llm.getResponse(chat, agentFunctions.map(f => f.definition));
+    const functionDefinitions = agentFunctions.map(f => f.definition);
+    const response = await llm.getResponse(chat, functionDefinitions);
 
     if (!response) {
       return ResultErr("No response from LLM.");

--- a/packages/agent-utils/src/llm/OpenAI.ts
+++ b/packages/agent-utils/src/llm/OpenAI.ts
@@ -6,7 +6,8 @@ import {
   ChatCompletionResponseMessage,
   ChatCompletionRequestMessageFunctionCall,
   Configuration,
-  OpenAIApi
+  OpenAIApi,
+  CreateChatCompletionRequest
 } from "openai";
 
 export {
@@ -19,6 +20,8 @@ interface OpenAIError {
   message: string;
   data: unknown;
 }
+
+export type OpenAIFunctions = CreateChatCompletionRequest["functions"]
 
 export class OpenAI implements LlmApi {
   private _configuration: Configuration;
@@ -48,7 +51,7 @@ export class OpenAI implements LlmApi {
 
   async getResponse(
     chat: Chat,
-    functionDefinitions: any[],
+    functionDefinitions: OpenAIFunctions,
     options?: LlmOptions,
     tries?: number
   ): Promise<ChatMessage | undefined> {
@@ -105,7 +108,7 @@ export class OpenAI implements LlmApi {
   private _createChatCompletion(options: {
     messages: ChatCompletionRequestMessage[];
     model?: string;
-    functions?: any;
+    functions?: OpenAIFunctions;
   } & LlmOptions) {
     return this._api.createChatCompletion({
       messages: options.messages,

--- a/packages/agent-utils/src/llm/llm.ts
+++ b/packages/agent-utils/src/llm/llm.ts
@@ -1,4 +1,4 @@
-import { Chat, ChatMessage } from ".";
+import { Chat, ChatMessage, OpenAIFunctions } from ".";
 
 export declare const LlmRoles: {
   readonly System: "system";
@@ -18,7 +18,7 @@ export interface LlmApi {
   getModel(): string;
   getResponse(
     chat: Chat,
-    functionDefinitions: any[],
+    functionDefinitions: OpenAIFunctions,
     options?: LlmOptions
   ): Promise<ChatMessage | undefined>;
 }


### PR DESCRIPTION
this PR aims to improve the typing of our codebase; this is inspired in the development of the [unit tests (which is still wip)](https://github.com/polywrap/evo.ninja/pull/203/files) 

- we define `OpenAiFunctions` types which is used by `llm.getResponse` method