### PR TITLE
prevent use of JS expressions in script arguments

### DIFF
--- a/packages/evo/src/agent-functions/executeScript.ts
+++ b/packages/evo/src/agent-functions/executeScript.ts
@@ -94,7 +94,7 @@ export const executeScript: AgentFunction<AgentContext> = {
         },
         arguments: {
           type: "string",
-          description: "The arguments to pass into the script being executed",
+          description: "JSON-formatted arguments to pass into the script being executed",
         },
         result: {
           type: "string",


### PR DESCRIPTION
This PR updates the description of the "arguments" method parameter that gpt4 uses to understand the correct format for arguments.

Addresses: https://github.com/polywrap/evo.ninja/issues/129

NOTE: will need testing to determine if #129 is in fact fixed.