### PR TITLE
chore: simplify the Chat's constructor

### DIFF
--- a/apps/browser/src/pages/Dojo.tsx
+++ b/apps/browser/src/pages/Dojo.tsx
@@ -173,7 +173,6 @@ function Dojo() {
       const userWorkspace = new EvoCore.InMemoryWorkspace();
       setUserWorkspace(userWorkspace);
       const chat = new EvoCore.Chat(
-        userWorkspace,
         llm,
         cl100k_base,
         logger

--- a/apps/cli/src/app.ts
+++ b/apps/cli/src/app.ts
@@ -89,7 +89,7 @@ export function createApp(config?: AppConfig): App {
     new FileSystemWorkspace(path.join(rootDir, "workspace"));
 
   // Chat
-  const chat = new Chat(userWorkspace, llm, cl100k_base, logger);
+  const chat = new Chat(llm, cl100k_base, logger);
 
   // Debug Logging
   let debugLog: DebugLog | undefined;

--- a/packages/agent-utils/src/llm/Chat.ts
+++ b/packages/agent-utils/src/llm/Chat.ts
@@ -1,5 +1,5 @@
 import { LlmApi, Tokenizer } from ".";
-import { Workspace, Logger } from "../sys";
+import { Logger } from "../sys";
 
 import {
   ChatCompletionRequestMessageRoleEnum,
@@ -37,11 +37,9 @@ export class Chat {
   private _chunkTokens: number;
 
   constructor(
-    private _workspace: Workspace,
     private _llm: LlmApi,
     private _tokenizer: Tokenizer,
-    private _logger: Logger,
-    private _msgsFile: string = ".msgs",
+    private _logger?: Logger,
   ) {
     this._maxContextTokens = this._llm.getMaxContextTokens();
 
@@ -94,9 +92,6 @@ export class Chat {
         msgLog.msgs.push(msg);
       }
     }
-
-    // Save the full log to disk
-    this._save();
   }
 
   public persistent(
@@ -135,7 +130,7 @@ export class Chat {
       return;
     }
 
-    this._logger.error(`! Max Tokens Exceeded (${this.tokens} / ${this._maxContextTokens})`);
+    this._logger?.error(`! Max Tokens Exceeded (${this.tokens} / ${this._maxContextTokens})`);
 
     // Start with "temporary" messages
     await this._summarize("temporary");
@@ -183,13 +178,6 @@ export class Chat {
     }
 
     return chunks;
-  }
-
-  private _save() {
-    this._workspace.writeFileSync(
-      this._msgsFile,
-      this.toString()
-    );
   }
 
   private async _summarize(

--- a/packages/evo/src/Evo.ts
+++ b/packages/evo/src/Evo.ts
@@ -54,7 +54,7 @@ export class Evo implements Agent {
     const { chat } = this.context;
     const createScriptWriter = (): ScriptWriter => {
       const workspace = new InMemoryWorkspace();
-      const chat = new Chat(workspace, this.llm, this.chat.tokenizer, this.logger);
+      const chat = new Chat(this.llm, this.chat.tokenizer, this.logger);
       return new ScriptWriter(this.llm, chat, this.logger, workspace);
     };
 

--- a/packages/evo/src/__tests__/llm.spec.ts
+++ b/packages/evo/src/__tests__/llm.spec.ts
@@ -3,7 +3,6 @@ import {
   Chat,
   ConsoleLogger,
   Logger,
-  InMemoryWorkspace,
   Env,
   ChatRole,
   ChatMessage
@@ -66,8 +65,8 @@ describe('LLM Test Suite', () => {
       logger
     );
 
-    const chat = new Chat(new InMemoryWorkspace(), llm, cl100k_base, logger);
-      
+    const chat = new Chat(llm, cl100k_base, logger);
+
     for (const msg of msgs.persistent.msgs) {
       chat.persistent(msg.role as ChatRole, msg.content);
     }


### PR DESCRIPTION
A `Workspace` for the `Chat` to save a `.msgs` file to is no longer needed now that we have the debug log added.