### PR TITLE
feat: workspace per goal

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,12 @@ In order to run Agent Protocol Benchmarks you must have all pre-requisites menti
 If you haven't fetched the submodules you can do it by doing the command:
 > `git submodule update --init`
 
-Then, in one terminal you must start the Agent Protocol HTTP Server: `yarn start:api`; in another terminal you
+Then, in one terminal you must start the Agent Protocol HTTP Server: `AGENT_WORKSPACE="../../workspace" yarn start:api`; in another terminal you
 must go to `benchmarks` folder and run:
 > `poetry shell`
 
 >`poetry install`
 
->`agbenchmark start --nc --test=TestCaseName`
+>`agbenchmark start --cutoff=300`
 
-This will run the `agbenchmark` framework against the API of the [Agent Protocol](https://github.com/AI-Engineers-Foundation/agent-protocol-sdk-js) 
+This will run the `agbenchmark` framework against the API of the [Agent Protocol](https://github.com/AI-Engineers-Foundation/agent-protocol-sdk-js). And will set a timeout of 5 minutes per task; if you'd like to run just one test in particular you can just add the flag `--test=TestCaseName`

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@evo-ninja/evo-agent": "0.1.0",
     "@evo-ninja/agent-utils": "~0.1.0",
-    "forked-agent-protocol": "0.0.3",
+    "forked-agent-protocol": "0.0.4",
     "chalk": "^4.1.2",
     "commander": "11.0.0",
     "dotenv": "~16.3.1",

--- a/apps/cli/src/api.ts
+++ b/apps/cli/src/api.ts
@@ -13,10 +13,17 @@ async function taskHandler(
   id: string,
   input: TaskInput | null
 ): Promise<StepHandler> {
+  const rootDir = path.join(process.cwd(), "../..");
   const workspace = new AgentProtocolWorkspace(
-    path.join(process.cwd(), "../../workspace", id)
+    path.join(rootDir, "workspace", id)
   );
-  const app = createApp({ userWorkspace: workspace });
+  console.log(rootDir);
+  const app = createApp({
+    rootDir,
+    userWorkspace: workspace,
+    taskId: id,
+    debug: true,
+  });
 
   let iterator = app.evo.run(input);
 
@@ -26,6 +33,12 @@ async function taskHandler(
       response.value && "message" in response.value
         ? response.value.message
         : "No message";
+
+    console.log("This is the response from the iteration: ");
+    console.log(response);
+
+    console.log("This is the output message: ");
+    console.log(outputMessage);
 
     workspace.writeArtifacts();
     const artifacts = workspace.getArtifacts();

--- a/apps/cli/src/api.ts
+++ b/apps/cli/src/api.ts
@@ -43,6 +43,14 @@ async function taskHandler(
     workspace.writeArtifacts();
     const artifacts = workspace.getArtifacts();
     workspace.cleanArtifacts();
+
+    if (response.done) {
+      if (!response.value.ok) {
+        app.debugLog?.stepError(response.value.error ?? "Unknown error");
+      } else {
+        app.debugLog?.stepLog(response.value.value as any);
+      }
+    }
     return {
       is_last: response.done,
       output: JSON.stringify(outputMessage),

--- a/apps/cli/src/api.ts
+++ b/apps/cli/src/api.ts
@@ -35,16 +35,12 @@ async function taskHandler(
         ? response.value.title
         : "No message";
 
-    console.log("Response from iterator");
-    console.log(response);
-    console.log("This is the output message:");
-    console.log(outputMessage);
     workspace.writeArtifacts();
     const artifacts = workspace.getArtifacts();
     workspace.cleanArtifacts();
     return {
       is_last: response.done,
-      output: outputMessage,
+      output: JSON.stringify(response.value),
       artifacts,
       //@ts-ignore
       name: outputMessage

--- a/apps/cli/src/api.ts
+++ b/apps/cli/src/api.ts
@@ -30,20 +30,25 @@ async function taskHandler(
     app.debugLog?.stepStart();
     const response = await iterator.next(stepInput);
     app.debugLog?.stepEnd();
-    const outputMessage =
+    const outputTitle =
       response.value && "title" in response.value
         ? response.value.title
-        : "No message";
+        : "No Title";
+
+    const outputMessage =
+      response.value && "message" in response.value
+        ? response.value.message
+        : "No Message";
 
     workspace.writeArtifacts();
     const artifacts = workspace.getArtifacts();
     workspace.cleanArtifacts();
     return {
       is_last: response.done,
-      output: JSON.stringify(response.value),
+      output: JSON.stringify(outputMessage),
       artifacts,
       //@ts-ignore
-      name: outputMessage
+      name: outputTitle,
     };
   }
   return stepHandler;

--- a/apps/cli/src/api.ts
+++ b/apps/cli/src/api.ts
@@ -17,7 +17,6 @@ async function taskHandler(
   const workspace = new AgentProtocolWorkspace(
     path.join(rootDir, "workspace", id)
   );
-  console.log(rootDir);
   const app = createApp({
     rootDir,
     userWorkspace: workspace,
@@ -25,31 +24,32 @@ async function taskHandler(
     debug: true,
   });
 
+  app.debugLog?.goalStart(input);
   let iterator = app.evo.run(input);
-
   async function stepHandler(stepInput: StepInput | null): Promise<StepResult> {
+    app.debugLog?.stepStart();
     const response = await iterator.next(stepInput);
+    app.debugLog?.stepEnd();
     const outputMessage =
-      response.value && "message" in response.value
-        ? response.value.message
+      response.value && "title" in response.value
+        ? response.value.title
         : "No message";
 
-    console.log("This is the response from the iteration: ");
+    console.log("Response from iterator");
     console.log(response);
-
-    console.log("This is the output message: ");
+    console.log("This is the output message:");
     console.log(outputMessage);
-
     workspace.writeArtifacts();
     const artifacts = workspace.getArtifacts();
     workspace.cleanArtifacts();
     return {
       is_last: response.done,
-      output: JSON.stringify(outputMessage),
+      output: outputMessage,
       artifacts,
+      //@ts-ignore
+      name: outputMessage
     };
   }
-
   return stepHandler;
 }
 

--- a/apps/cli/src/app.ts
+++ b/apps/cli/src/app.ts
@@ -97,7 +97,7 @@ export function createApp(config?: AppConfig): App {
 
   if (config?.debug) {
     debugLog = new DebugLog(
-      new FileSystemWorkspace(path.join(rootDir, "debug"))
+      new FileSystemWorkspace(workspacePath)
     );
 
     // Wrap the LLM API

--- a/apps/cli/src/app.ts
+++ b/apps/cli/src/app.ts
@@ -42,6 +42,7 @@ export interface AppConfig {
   timeout?: Timeout;
   userWorkspace?: Workspace;
   debug?: boolean;
+  taskId?: string;
 }
 
 export function createApp(config?: AppConfig): App {
@@ -49,15 +50,16 @@ export function createApp(config?: AppConfig): App {
     ? path.resolve(config?.rootDir)
     : path.join(__dirname, "../../../");
 
-  const env = new Env(process.env as Record<string, string>);
-
-  // Chat Log File
   const date = new Date();
-  const logFile = `chat_${date.getFullYear()}-${
+  const defaultId = `${date.getFullYear()}-${
     date.getMonth() + 1
-  }-${date.getDate()}_${date.getHours()}-${date.getMinutes()}-${date.getSeconds()}.md`;
-  const logWorkspace = new FileSystemWorkspace(path.join(rootDir, "chats"));
-  const fileLogger = new FileLogger(logWorkspace.toWorkspacePath(logFile));
+  }-${date.getDate()}_${date.getHours()}-${date.getMinutes()}-${date.getSeconds()}`;
+  const taskId = config?.taskId ?? defaultId;
+  const env = new Env(process.env as Record<string, string>);
+  const workspacePath = path.join(rootDir, "workspace", taskId);
+  // Chat Log File
+  const logWorkspace = new FileSystemWorkspace(workspacePath);
+  const fileLogger = new FileLogger(logWorkspace.toWorkspacePath("chat.md"));
 
   // Logger
   const consoleLogger = new ConsoleLogger();
@@ -85,8 +87,7 @@ export function createApp(config?: AppConfig): App {
 
   // User Workspace
   const userWorkspace =
-    config?.userWorkspace ??
-    new FileSystemWorkspace(path.join(rootDir, "workspace"));
+    config?.userWorkspace ?? new FileSystemWorkspace(workspacePath);
 
   // Chat
   const chat = new Chat(llm, cl100k_base, logger);

--- a/apps/cli/src/diagnostic/DebugLlmApi.ts
+++ b/apps/cli/src/diagnostic/DebugLlmApi.ts
@@ -34,8 +34,6 @@ export class DebugLlmApi implements LlmApi {
     );
 
     time.end();
-    console.log("get response debug")
-    console.log(this)
     this.debugLog.stepLlmReq(
       time,
       chat.export(),

--- a/apps/cli/src/diagnostic/DebugLlmApi.ts
+++ b/apps/cli/src/diagnostic/DebugLlmApi.ts
@@ -34,7 +34,8 @@ export class DebugLlmApi implements LlmApi {
     );
 
     time.end();
-
+    console.log("get response debug")
+    console.log(this)
     this.debugLog.stepLlmReq(
       time,
       chat.export(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -6360,10 +6360,10 @@ fork-ts-checker-webpack-plugin@^6.5.0:
     semver "^7.3.2"
     tapable "^1.0.0"
 
-forked-agent-protocol@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/forked-agent-protocol/-/forked-agent-protocol-0.0.3.tgz#0a1a3832f65dec12044b4cac23a51f30f345d6d2"
-  integrity sha512-h60/xtipI3pRvUMgBcl/Ljor99c1UBP9qCpYqz7PZCCAXBGq+sqGxe6mWmvcFdkIrkTfkOWREc31Ktg2asDE/w==
+forked-agent-protocol@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/forked-agent-protocol/-/forked-agent-protocol-0.0.4.tgz#4a1798da30f8254f068956b8fd80e78fe4b82592"
+  integrity sha512-XTDNq1cF9/lpQgBf6jNm12DZZq21ND7vPvGgfOThSPhxlNNaPbyjfGrL3Ro7XbWnlF+xo/52ScfUEMm4D6SdrQ==
   dependencies:
     "@types/uuid" "^9.0.2"
     express "^4.18.2"
@@ -11332,6 +11332,7 @@ string-natural-compare@^3.0.1:
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -12636,6 +12637,7 @@ workbox-window@6.6.1:
     workbox-core "6.6.1"
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
this PR aims to improve the structure of logs, right now we have a folder for `chat`, `debug` and `workspace`; if we would like to debug with benchmark or multiple test this would not be reliable, so I went ahead and applied how benchmark works and added an id for every goal executed (it's a timestamp when running from CLI)

also i attached the `DebugLlmApi` to the API process and we're able to see logs, when running the benchmarks, the workspace logs would have the following structure:
![image](https://github.com/polywrap/evo.ninja/assets/21031138/106e574e-7f53-42e1-ab95-1b58951be64c)

it's worth mentioning that [i had to update the `agent-protocol` library](https://github.com/AI-Engineers-Foundation/agent-protocol-sdk-js/pull/1/commits/e339b61763ab32798c7d6f83a100c9826661b84c) to support [the `name` attribute from step](https://github.com/cbrzn/evo.ninja/blob/8b9e60d88d42a9ada4627e53b0fb3b03d5ddc438/apps/cli/src/api.ts#L46), hence, the bump of the version; this way we can see the logs correctly when running the benchmarks, example:
![image](https://github.com/polywrap/evo.ninja/assets/21031138/ce269c8d-c06c-47a4-94d3-8a1a6e297e97)

