### PR TITLE
chore: create `AgentOutputType` enum and use it in `AgentOutput[]`

### DIFF
--- a/packages/agent-utils/src/agent/AgentOutput.ts
+++ b/packages/agent-utils/src/agent/AgentOutput.ts
@@ -1,5 +1,5 @@
 export enum AgentOutputType {
-  SUCCESS = "sucess",
+  SUCCESS = "success",
   ERROR = "error",
   INFO = "info",
   WARNING = "warning"

--- a/packages/agent-utils/src/agent/AgentOutput.ts
+++ b/packages/agent-utils/src/agent/AgentOutput.ts
@@ -1,5 +1,13 @@
+export enum AgentOutputType {
+  SUCCESS = "sucess",
+  ERROR = "error",
+  INFO = "info",
+  WARNING = "warning"
+
+}
+
 export interface AgentOutput {
-  type: "success" | "error" | "info" | "warning";
+  type: AgentOutputType;
   title: string;
   content?: string;
 }

--- a/packages/agent-utils/src/agent/AgentOutput.ts
+++ b/packages/agent-utils/src/agent/AgentOutput.ts
@@ -1,10 +1,11 @@
-export enum AgentOutputType {
-  SUCCESS = "success",
-  ERROR = "error",
-  INFO = "info",
-  WARNING = "warning"
+export const AgentOutputType = {
+  Success: "success",
+  Error: "error",
+  Info: "info",
+  Warning: "warning"
+} as const;
 
-}
+export type AgentOutputType = typeof AgentOutputType[keyof typeof AgentOutputType];
 
 export interface AgentOutput {
   type: AgentOutputType;

--- a/packages/agent-utils/src/agent/basicFunctionCallLoop.ts
+++ b/packages/agent-utils/src/agent/basicFunctionCallLoop.ts
@@ -39,7 +39,7 @@ export async function* basicFunctionCallLoop<TContext extends { llm: LlmApi, cha
 
       if (!result.ok) {
         chat.temporary("system", result.error);
-        yield { type: AgentOutputType.ERROR, title: `Failed to execute ${name}!`, content: result.error } as AgentOutput;
+        yield { type: AgentOutputType.Error, title: `Failed to execute ${name}!`, content: result.error } as AgentOutput;
         continue;
       }
 
@@ -67,14 +67,14 @@ async function* _preventLoopAndSaveMsg(chat: Chat, response: ChatMessage, loopPr
     chat.messages[chat.messages.length - 2].content === response.content) {
       chat.temporary("system", loopPreventionPrompt);
       yield {
-        type: AgentOutputType.WARNING,
+        type: AgentOutputType.Warning,
         title: "Loop prevention",
         content: loopPreventionPrompt
       } as AgentOutput;
   } else {
     chat.temporary(response);
     yield {
-      type: AgentOutputType.SUCCESS,
+      type: AgentOutputType.Success,
       title: "Agent response",
       content: response.content ?? ""
     } as AgentOutput;

--- a/packages/agent-utils/src/agent/basicFunctionCallLoop.ts
+++ b/packages/agent-utils/src/agent/basicFunctionCallLoop.ts
@@ -1,5 +1,5 @@
 import { Chat, ChatMessage, LlmApi } from "../llm";
-import { AgentOutput } from "./AgentOutput";
+import { AgentOutput, AgentOutputType } from "./AgentOutput";
 import { RunResult } from "./agent";
 import {
   ExecuteAgentFunction,
@@ -39,7 +39,7 @@ export async function* basicFunctionCallLoop<TContext extends { llm: LlmApi, cha
 
       if (!result.ok) {
         chat.temporary("system", result.error);
-        yield { type: "error", title: `Failed to execute ${name}!`, content: result.error } as AgentOutput;
+        yield { type: AgentOutputType.ERROR, title: `Failed to execute ${name}!`, content: result.error } as AgentOutput;
         continue;
       }
 
@@ -67,14 +67,14 @@ async function* _preventLoopAndSaveMsg(chat: Chat, response: ChatMessage, loopPr
     chat.messages[chat.messages.length - 2].content === response.content) {
       chat.temporary("system", loopPreventionPrompt);
       yield {
-        type: "warning",
+        type: AgentOutputType.WARNING,
         title: "Loop prevention",
         content: loopPreventionPrompt
       } as AgentOutput;
   } else {
     chat.temporary(response);
     yield {
-      type: "success",
+      type: AgentOutputType.SUCCESS,
       title: "Agent response",
       content: response.content ?? ""
     } as AgentOutput;

--- a/packages/evo/src/agent-functions/createScript.ts
+++ b/packages/evo/src/agent-functions/createScript.ts
@@ -1,5 +1,5 @@
 import { Result, ResultErr, ResultOk } from "@polywrap/result";
-import { AgentFunction, AgentFunctionResult, ChatMessageBuilder } from "@evo-ninja/agent-utils";
+import { AgentFunction, AgentFunctionResult, AgentOutputType, ChatMessageBuilder } from "@evo-ninja/agent-utils";
 import { ScriptWriter } from "@evo-ninja/js-script-writer-agent";
 import { AgentContext } from "../AgentContext";
 import { FUNCTION_CALL_FAILED, FUNCTION_CALL_SUCCESS_CONTENT } from "../prompts";
@@ -15,7 +15,7 @@ type FuncParameters = {
 const SUCCESS = (script: Script, params: FuncParameters): AgentFunctionResult => ({
   outputs: [
     {
-      type: "success",
+      type: AgentOutputType.SUCCESS,
       title:`Created '${params.namespace}' script.`,
       content: FUNCTION_CALL_SUCCESS_CONTENT(
         FN_NAME,
@@ -36,7 +36,7 @@ const SUCCESS = (script: Script, params: FuncParameters): AgentFunctionResult =>
 const CANNOT_CREATE_SCRIPTS_ON_AGENT_NAMESPACE = (params: FuncParameters): AgentFunctionResult => ({
   outputs: [
     {
-      type: "error",
+      type: AgentOutputType.ERROR,
       title: `Failed to create '${params.namespace}' script!`,
       content: FUNCTION_CALL_FAILED(
         params, 

--- a/packages/evo/src/agent-functions/createScript.ts
+++ b/packages/evo/src/agent-functions/createScript.ts
@@ -15,7 +15,7 @@ type FuncParameters = {
 const SUCCESS = (script: Script, params: FuncParameters): AgentFunctionResult => ({
   outputs: [
     {
-      type: AgentOutputType.SUCCESS,
+      type: AgentOutputType.Success,
       title:`Created '${params.namespace}' script.`,
       content: FUNCTION_CALL_SUCCESS_CONTENT(
         FN_NAME,
@@ -36,7 +36,7 @@ const SUCCESS = (script: Script, params: FuncParameters): AgentFunctionResult =>
 const CANNOT_CREATE_SCRIPTS_ON_AGENT_NAMESPACE = (params: FuncParameters): AgentFunctionResult => ({
   outputs: [
     {
-      type: AgentOutputType.ERROR,
+      type: AgentOutputType.Error,
       title: `Failed to create '${params.namespace}' script!`,
       content: FUNCTION_CALL_FAILED(
         params, 

--- a/packages/evo/src/agent-functions/executeScript.ts
+++ b/packages/evo/src/agent-functions/executeScript.ts
@@ -16,7 +16,7 @@ type FuncParameters = {
 const SUCCESS = (scriptName: string, result: any, params: FuncParameters): AgentFunctionResult => ({
   outputs: [
     {
-      type: AgentOutputType.SUCCESS,
+      type: AgentOutputType.Success,
       title: `Executed '${scriptName}' script.`,
       content: FUNCTION_CALL_SUCCESS_CONTENT(
         FN_NAME,
@@ -34,7 +34,7 @@ const SUCCESS = (scriptName: string, result: any, params: FuncParameters): Agent
 const EXECUTE_SCRIPT_ERROR_RESULT = (scriptName: string, error: string | undefined, params: FuncParameters): AgentFunctionResult => ({
   outputs: [
     {
-      type: AgentOutputType.ERROR,
+      type: AgentOutputType.Error,
       title: `'${scriptName}' script failed to execute!`,
       content: FUNCTION_CALL_FAILED(params, FN_NAME, error ?? "Unknown error"),
     }

--- a/packages/evo/src/agent-functions/executeScript.ts
+++ b/packages/evo/src/agent-functions/executeScript.ts
@@ -1,6 +1,6 @@
 import JSON5 from "json5";
 import { Result, ResultErr, ResultOk } from "@polywrap/result";
-import { AgentFunction, AgentFunctionResult, ChatMessageBuilder, trimText } from "@evo-ninja/agent-utils";
+import { AgentFunction, AgentFunctionResult, AgentOutputType, ChatMessageBuilder, trimText } from "@evo-ninja/agent-utils";
 import { AgentContext } from "../AgentContext";
 import { FUNCTION_CALL_FAILED, FUNCTION_CALL_SUCCESS_CONTENT } from "../prompts";
 import { JsEngine_GlobalVar, JsEngine, shimCode } from "../wrap";
@@ -16,7 +16,7 @@ type FuncParameters = {
 const SUCCESS = (scriptName: string, result: any, params: FuncParameters): AgentFunctionResult => ({
   outputs: [
     {
-      type: "success",
+      type: AgentOutputType.SUCCESS,
       title: `Executed '${scriptName}' script.`,
       content: FUNCTION_CALL_SUCCESS_CONTENT(
         FN_NAME,
@@ -34,7 +34,7 @@ const SUCCESS = (scriptName: string, result: any, params: FuncParameters): Agent
 const EXECUTE_SCRIPT_ERROR_RESULT = (scriptName: string, error: string | undefined, params: FuncParameters): AgentFunctionResult => ({
   outputs: [
     {
-      type: "success",
+      type: AgentOutputType.ERROR,
       title: `'${scriptName}' script failed to execute!`,
       content: FUNCTION_CALL_FAILED(params, FN_NAME, error ?? "Unknown error"),
     }

--- a/packages/evo/src/agent-functions/findScript.ts
+++ b/packages/evo/src/agent-functions/findScript.ts
@@ -13,7 +13,7 @@ type FuncParameters = {
 const SUCCESS = (params: FuncParameters, candidates: Script[]): AgentFunctionResult => ({
   outputs: [
     {
-      type: AgentOutputType.SUCCESS,
+      type: AgentOutputType.Success,
       title: FIND_SCRIPT_TITLE(params),
       content: FUNCTION_CALL_SUCCESS_CONTENT(
         FN_NAME,
@@ -37,7 +37,7 @@ const SUCCESS = (params: FuncParameters, candidates: Script[]): AgentFunctionRes
 const NO_SCRIPTS_FOUND_ERROR = (params: FuncParameters): AgentFunctionResult => ({
   outputs: [
     {
-      type: AgentOutputType.ERROR,
+      type: AgentOutputType.Error,
       title: FIND_SCRIPT_TITLE(params),
       content: FUNCTION_CALL_SUCCESS_CONTENT(
         FN_NAME,

--- a/packages/evo/src/agent-functions/findScript.ts
+++ b/packages/evo/src/agent-functions/findScript.ts
@@ -1,5 +1,5 @@
 import { Result, ResultOk } from "@polywrap/result";
-import { AgentFunction, AgentFunctionResult, ChatMessageBuilder } from "@evo-ninja/agent-utils";
+import { AgentFunction, AgentFunctionResult, AgentOutputType, ChatMessageBuilder } from "@evo-ninja/agent-utils";
 import { AgentContext } from "../AgentContext";
 import { Script } from "../Scripts";
 import { FUNCTION_CALL_SUCCESS_CONTENT } from "../prompts";
@@ -13,7 +13,7 @@ type FuncParameters = {
 const SUCCESS = (params: FuncParameters, candidates: Script[]): AgentFunctionResult => ({
   outputs: [
     {
-      type: "success",
+      type: AgentOutputType.SUCCESS,
       title: FIND_SCRIPT_TITLE(params),
       content: FUNCTION_CALL_SUCCESS_CONTENT(
         FN_NAME,
@@ -37,7 +37,7 @@ const SUCCESS = (params: FuncParameters, candidates: Script[]): AgentFunctionRes
 const NO_SCRIPTS_FOUND_ERROR = (params: FuncParameters): AgentFunctionResult => ({
   outputs: [
     {
-      type: "success",
+      type: AgentOutputType.ERROR,
       title: FIND_SCRIPT_TITLE(params),
       content: FUNCTION_CALL_SUCCESS_CONTENT(
         FN_NAME,

--- a/packages/evo/src/agent-functions/readVar.ts
+++ b/packages/evo/src/agent-functions/readVar.ts
@@ -11,7 +11,7 @@ type FuncParameters = {
 const SUCCESS = (params: FuncParameters, varValue: string): AgentFunctionResult => ({
   outputs: [
     {
-      type: AgentOutputType.SUCCESS,
+      type: AgentOutputType.Success,
       title: `Read '${params.name}' variable.`,
       content: FUNCTION_CALL_SUCCESS_CONTENT(
         FN_NAME,
@@ -28,7 +28,7 @@ const SUCCESS = (params: FuncParameters, varValue: string): AgentFunctionResult 
 const VAR_NOT_FOUND_ERROR = (params: FuncParameters): AgentFunctionResult => ({
   outputs: [
     {
-      type: AgentOutputType.ERROR,
+      type: AgentOutputType.Error,
       title: `Failed to read '${params.name}' variable.`, 
       content: FUNCTION_CALL_FAILED(params, FN_NAME, `Global variable {{${params.name}}} not found.`)
     }

--- a/packages/evo/src/agent-functions/readVar.ts
+++ b/packages/evo/src/agent-functions/readVar.ts
@@ -1,5 +1,5 @@
 import { Result, ResultOk } from "@polywrap/result";
-import { AgentFunction, AgentFunctionResult, ChatMessageBuilder, trimText } from "@evo-ninja/agent-utils";
+import { AgentFunction, AgentFunctionResult, AgentOutputType, ChatMessageBuilder, trimText } from "@evo-ninja/agent-utils";
 import { AgentContext } from "../AgentContext";
 import { FUNCTION_CALL_FAILED, FUNCTION_CALL_SUCCESS_CONTENT } from "../prompts";
 
@@ -11,7 +11,7 @@ type FuncParameters = {
 const SUCCESS = (params: FuncParameters, varValue: string): AgentFunctionResult => ({
   outputs: [
     {
-      type: "success",
+      type: AgentOutputType.SUCCESS,
       title: `Read '${params.name}' variable.`,
       content: FUNCTION_CALL_SUCCESS_CONTENT(
         FN_NAME,
@@ -28,7 +28,7 @@ const SUCCESS = (params: FuncParameters, varValue: string): AgentFunctionResult 
 const VAR_NOT_FOUND_ERROR = (params: FuncParameters): AgentFunctionResult => ({
   outputs: [
     {
-      type: "success",
+      type: AgentOutputType.ERROR,
       title: `Failed to read '${params.name}' variable.`, 
       content: FUNCTION_CALL_FAILED(params, FN_NAME, `Global variable {{${params.name}}} not found.`)
     }

--- a/packages/js-script-writer/src/agent-functions/think.ts
+++ b/packages/js-script-writer/src/agent-functions/think.ts
@@ -10,7 +10,7 @@ type FuncParameters = {
 const SUCCESS = (params: FuncParameters): AgentFunctionResult => ({
   outputs: [
     {
-      type: AgentOutputType.SUCCESS,
+      type: AgentOutputType.Success,
       title: `Thinking...`,
       content: 
         `## Thoughts:\n` +

--- a/packages/js-script-writer/src/agent-functions/think.ts
+++ b/packages/js-script-writer/src/agent-functions/think.ts
@@ -1,5 +1,5 @@
 import { Result, ResultOk } from "@polywrap/result";
-import { AgentFunction, AgentFunctionResult, ChatMessageBuilder } from "@evo-ninja/agent-utils";
+import { AgentFunction, AgentFunctionResult, AgentOutputType, ChatMessageBuilder } from "@evo-ninja/agent-utils";
 import { AgentContext } from "../AgentContext";
 
 const FN_NAME = "think";
@@ -10,7 +10,7 @@ type FuncParameters = {
 const SUCCESS = (params: FuncParameters): AgentFunctionResult => ({
   outputs: [
     {
-      type: "success",
+      type: AgentOutputType.SUCCESS,
       title: `Thinking...`,
       content: 
         `## Thoughts:\n` +

--- a/packages/js-script-writer/src/agent-functions/writeFunction.ts
+++ b/packages/js-script-writer/src/agent-functions/writeFunction.ts
@@ -21,7 +21,7 @@ type FuncParameters = {
 const SUCCESS = (params: FuncParameters): AgentFunctionResult => ({
   outputs: [
     {
-      type: AgentOutputType.SUCCESS,
+      type: AgentOutputType.Success,
       title: `Wrote function '${params.namespace}'.`,
       content: `Wrote the function ${params.namespace} to the workspace.`
     }
@@ -34,7 +34,7 @@ const SUCCESS = (params: FuncParameters): AgentFunctionResult => ({
 const CANNOT_CREATE_IN_AGENT_NAMESPACE_ERROR = (params: FuncParameters): AgentFunctionResult => ({
   outputs: [
     {
-      type: AgentOutputType.ERROR,
+      type: AgentOutputType.Error,
       title: `Failed to write function '${params.namespace}'!`,
       content: FUNCTION_CALL_FAILED(FN_NAME, `Cannot create a function with namespace ${params.namespace}. Namespaces starting with 'agent.' are reserved.`, params)
     }
@@ -50,7 +50,7 @@ const CANNOT_CREATE_IN_AGENT_NAMESPACE_ERROR = (params: FuncParameters): AgentFu
 const CANNOT_REQUIRE_LIB_ERROR = (params: FuncParameters): AgentFunctionResult => ({
   outputs: [
     {
-      type: AgentOutputType.ERROR,
+      type: AgentOutputType.Error,
       title:`Failed to write function '${params.namespace}'!`,
       content: FUNCTION_CALL_FAILED(FN_NAME,  `Cannot require libraries other than ${allowedLibs.join(", ")}.`, params)
     }

--- a/packages/js-script-writer/src/agent-functions/writeFunction.ts
+++ b/packages/js-script-writer/src/agent-functions/writeFunction.ts
@@ -1,7 +1,7 @@
 import { AgentContext } from "../AgentContext";
 import { FUNCTION_CALL_FAILED } from "../prompts";
 
-import { AgentFunction, AgentFunctionResult, ChatMessageBuilder } from "@evo-ninja/agent-utils";
+import { AgentFunction, AgentFunctionResult, AgentOutputType, ChatMessageBuilder } from "@evo-ninja/agent-utils";
 import { Result, ResultOk } from "@polywrap/result";
 
 const allowedLibs = [
@@ -21,7 +21,7 @@ type FuncParameters = {
 const SUCCESS = (params: FuncParameters): AgentFunctionResult => ({
   outputs: [
     {
-      type: "success",
+      type: AgentOutputType.SUCCESS,
       title: `Wrote function '${params.namespace}'.`,
       content: `Wrote the function ${params.namespace} to the workspace.`
     }
@@ -34,7 +34,7 @@ const SUCCESS = (params: FuncParameters): AgentFunctionResult => ({
 const CANNOT_CREATE_IN_AGENT_NAMESPACE_ERROR = (params: FuncParameters): AgentFunctionResult => ({
   outputs: [
     {
-      type: "success",
+      type: AgentOutputType.ERROR,
       title: `Failed to write function '${params.namespace}'!`,
       content: FUNCTION_CALL_FAILED(FN_NAME, `Cannot create a function with namespace ${params.namespace}. Namespaces starting with 'agent.' are reserved.`, params)
     }
@@ -50,7 +50,7 @@ const CANNOT_CREATE_IN_AGENT_NAMESPACE_ERROR = (params: FuncParameters): AgentFu
 const CANNOT_REQUIRE_LIB_ERROR = (params: FuncParameters): AgentFunctionResult => ({
   outputs: [
     {
-      type: "success",
+      type: AgentOutputType.ERROR,
       title:`Failed to write function '${params.namespace}'!`,
       content: FUNCTION_CALL_FAILED(FN_NAME,  `Cannot require libraries other than ${allowedLibs.join(", ")}.`, params)
     }


### PR DESCRIPTION
this PR aims to introduce the type `AgentOutputType` to improve the maintainability of the `AgentOutput` usage; also, I noticed that we had some wrong usage of some strings, for example, in [`writeFunction.ts`](https://github.com/polywrap/evo.ninja/compare/chore/agent-function-type?expand=1#diff-298a3b6aa95764057b78670b60ec7488fd24af43f7b96f6e3c0b65b48a39c72eL37) function