### PR TITLE
adds fix for args parsing

### DIFF
--- a/packages/evo/src/agent-functions/executeScript.ts
+++ b/packages/evo/src/agent-functions/executeScript.ts
@@ -115,7 +115,12 @@ export const executeScript: AgentFunction<AgentContext> = {
         }
 
         let args: any = undefined;
-        args = params.arguments ? params.arguments.replace(/\{\{/g, "\\{\\{").replace(/\}\}/g, "\\}\\}") : "{}";
+        args = params.arguments
+          ? params.arguments
+            .replace(/\{\{/g, "\\{\\{")
+            .replace(/\}\}/g, "\\}\\}")
+            .replace(/\\\"/g, '"')
+          : "{}";
         try {
 
           args = JSON5.parse(params.arguments);


### PR DESCRIPTION
With the prompt `web scrape all the links from https://polywrap.io`, the string Evo tries to pass to `agent.speak` is invalid JSON:

```json
{
  "namespace": "agent.speak",
  "arguments": "{\"message\":\"Here are the links I found on https://polywrap.io: \n1. https://docs.polywrap.io/ \n2. https://ens.domains/ \n3. https://ethereum.org \n4. https://gelato.network/ \n5. https://ipfs.tech/ \n6. https://near.org \n7. https://pokt.network \n8. https://polkadot.network \n9. https://gnosis-safe.io/ \n10. https://tezos.com \n11. https://uniswap.org \n12. https://coinfund.io/ \n13. https://placeholder.vc/ \n14. https://trueventures.com/ \n15. https://portal.vc/ \n16. https://zeeprime.capital/ \n17. https://atka.io/ \n18. https://trgc.io/ \n19. https://ascensiveassets.com/ \n20. https://rarestone.capital/ \n21. https://gnosis.com \n22. https://iosg.vc/ \n23. https://blockwatch.cc/ \n24. https://chainsafe.io/ \n25. https://consideritdone.tech/ \n26. https://dorg.tech \n27. https://discord.com/invite/Z5m88a5qWu \n28. https://wrapscan.io/ \n29. https://github.com/polywrap \n30. https://twitter.com/polywrap_io \n31. https://blog.polywrap.io/ \n32. https://handbook.polywrap.io/ \n33. https://forum.polywrap.io/ \n34. https://snapshot.org/#/polywrap.eth\"}",
  "result": "_"
}
```

This can be fixed to with a simple `String.replace`:
```json
{
  "namespace": "agent.speak",
  "arguments": "{\"message\":\"Here are the links I found on https://polywrap.io: \n1. https://docs.polywrap.io/ \n2. https://ens.domains/ \n3. https://ethereum.org \n4. https://gelato.network/ \n5. https://ipfs.tech/ \n6. https://near.org \n7. https://pokt.network \n8. https://polkadot.network \n9. https://gnosis-safe.io/ \n10. https://tezos.com \n11. https://uniswap.org \n12. https://coinfund.io/ \n13. https://placeholder.vc/ \n14. https://trueventures.com/ \n15. https://portal.vc/ \n16. https://zeeprime.capital/ \n17. https://atka.io/ \n18. https://trgc.io/ \n19. https://ascensiveassets.com/ \n20. https://rarestone.capital/ \n21. https://gnosis.com \n22. https://iosg.vc/ \n23. https://blockwatch.cc/ \n24. https://chainsafe.io/ \n25. https://consideritdone.tech/ \n26. https://dorg.tech \n27. https://discord.com/invite/Z5m88a5qWu \n28. https://wrapscan.io/ \n29. https://github.com/polywrap \n30. https://twitter.com/polywrap_io \n31. https://blog.polywrap.io/ \n32. https://handbook.polywrap.io/ \n33. https://forum.polywrap.io/ \n34. https://snapshot.org/#/polywrap.eth\"}",
  "result": "speakResult"
}
```