### PR TITLE
fix: chat logs initialization

### DIFF
--- a/packages/agent-utils/src/llm/Chat.ts
+++ b/packages/agent-utils/src/llm/Chat.ts
@@ -18,7 +18,9 @@ export class Chat {
     private _tokenizer: Tokenizer,
     private _contextWindow?: ContextWindow,
     private _logger?: Logger,
-  ) { }
+  ) { 
+    this._chatLogs = new ChatLogs()
+  }
 
   get chatLogs(): ChatLogs {
     return this._chatLogs;


### PR DESCRIPTION
right now we're not initializing the chat logs inside of the `Chat` class, this was causing an error - hence, this fix