### PR TITLE
remove context.globals from jsEval

### DIFF
--- a/packages/evo/src/agent-functions/executeScript.ts
+++ b/packages/evo/src/agent-functions/executeScript.ts
@@ -150,8 +150,7 @@ export const executeScript: AgentFunction<AgentContext> = {
         }
 
         const globals: JsEngine_GlobalVar[] =
-          Object.entries(args).concat(Object.entries(context.globals))
-            .map((entry) => ({
+          Object.entries(args).map((entry) => ({
               name: entry[0],
               value: JSON.stringify(entry[1]),
             })


### PR DESCRIPTION
we no longer need to pass in the contents of context.globals in jsEval in executeScript, because the code writer doesn't know about them anyway