### PR TITLE
Implemented script for parallel running of commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ debug
 coverage
 workspace
 chats
+.logs
 
 !/benchmarks/agbenchmark_config/config.json
 /benchmarks/agbenchmark_config

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Ensure you have GNU parallel installed
+if ! command -v parallel >/dev/null; then
+    echo "Please install GNU parallel first."
+    exit 1
+fi
+
+# Run each command in parallel and log its output to a corresponding log file
+parallel --jobs 5 --results logs/ "{}" :::: commands.txt

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -9,5 +9,9 @@ fi
 # Get the number of jobs from the command line argument (default to 1 if not provided)
 NUM_JOBS="${1:-1}"
 
+# Delete the .logs directory and recreate it
+rm -rf .logs/
+mkdir -p .logs/
+
 # Run each command in parallel and log its output to a corresponding log file
-parallel --jobs "$NUM_JOBS" --results logs/ "{}" :::: commands.txt
+parallel --jobs "$NUM_JOBS" --results .logs/ "{}" :::: commands.txt

--- a/benchmarks/bench.sh
+++ b/benchmarks/bench.sh
@@ -6,5 +6,8 @@ if ! command -v parallel >/dev/null; then
     exit 1
 fi
 
+# Get the number of jobs from the command line argument (default to 1 if not provided)
+NUM_JOBS="${1:-1}"
+
 # Run each command in parallel and log its output to a corresponding log file
-parallel --jobs 5 --results logs/ "{}" :::: commands.txt
+parallel --jobs "$NUM_JOBS" --results logs/ "{}" :::: commands.txt

--- a/benchmarks/commands.txt
+++ b/benchmarks/commands.txt
@@ -1,0 +1,2 @@
+agbenchmark --nc --test=Search
+agbenchmark --nc --test=BasicRetrieval


### PR DESCRIPTION
We can now specify commands in commands.txt
## Usage
Run them with:
```bash
./bench.sh
```
By default they will run sequentially (num of jobs = 1)
You can configure the number of jobs with:
```bash
./bench.sh 3
```
Will run it with 3 jobs in parallel.

## Setup:
Install parallel with:
```bash
sudo apt install parallel
```
Set permissions on script with:
```bash
chmod +x ./bench.sh
```