### PR TITLE
chore: Add `scriptExecutor` result to llm chat + fix function call & result messages

### DIFF
--- a/packages/agent-utils/src/agent/ChatMessageBuilder.ts
+++ b/packages/agent-utils/src/agent/ChatMessageBuilder.ts
@@ -18,4 +18,12 @@ export class ChatMessageBuilder {
       }
     };
   }
+
+  static functionCallResponse(funcName: string, content: string): ChatMessage {
+    return {
+      role: "function",
+      content,
+      name: funcName
+    }
+  }
 }

--- a/packages/agent-utils/src/agent/ChatMessageBuilder.ts
+++ b/packages/agent-utils/src/agent/ChatMessageBuilder.ts
@@ -8,10 +8,10 @@ export class ChatMessageBuilder {
     };
   }
 
-  static functionCall<TFuncParams>(funcName: string, params: TFuncParams, content: string = ""): ChatMessage {
+  static functionCall<TFuncParams>(funcName: string, params: TFuncParams): ChatMessage {
     return {
       role: "assistant",
-      content,
+      content: "",
       function_call: {
         name: funcName,
         arguments: JSON.stringify(params)
@@ -19,11 +19,11 @@ export class ChatMessageBuilder {
     };
   }
 
-  static functionCallResponse(funcName: string, content: string): ChatMessage {
+  static functionCallResult(funcName: string, result: string): ChatMessage {
     return {
       role: "function",
-      content,
-      name: funcName
-    }
+      name: funcName,
+      content: result
+    };
   }
 }

--- a/packages/evo/src/agent-functions/createScript.ts
+++ b/packages/evo/src/agent-functions/createScript.ts
@@ -28,7 +28,7 @@ const SUCCESS = (script: Script, params: FuncParameters): AgentFunctionResult =>
   ],
   messages: [
     ChatMessageBuilder.functionCall(FN_NAME, params),
-    ChatMessageBuilder.system(`Script '${script.name}' created.`)
+    ChatMessageBuilder.functionCallResult(FN_NAME, `Script '${script.name}' created.`)
   ]
 });
 
@@ -46,7 +46,10 @@ const CANNOT_CREATE_SCRIPTS_ON_AGENT_NAMESPACE = (params: FuncParameters): Agent
   ],
   messages: [
     ChatMessageBuilder.functionCall(FN_NAME, params),
-    ChatMessageBuilder.system(`Scripts in the 'agent' namespace cannot be created. Try searching for an existing script instead.`)
+    ChatMessageBuilder.functionCallResult(
+      FN_NAME,
+      `Error: Scripts in the 'agent' namespace cannot be created. Try searching for an existing script instead.`
+    )
   ]
 });
 

--- a/packages/evo/src/agent-functions/findScript.ts
+++ b/packages/evo/src/agent-functions/findScript.ts
@@ -32,7 +32,8 @@ const SUCCESS = (params: FuncParameters, candidates: Script[]): AgentFunctionRes
   ],
   messages: [
     ChatMessageBuilder.functionCall(FN_NAME, params),
-    ChatMessageBuilder.system(
+    ChatMessageBuilder.functionCallResult(
+      FN_NAME,
       `Found the following results for script '${params.namespace}'\n` + 
       `${candidates.map((c) => `Namespace: ${c.name}\nArguments: ${c.arguments}\nDescription: ${c.description}`).join("\n--------------\n")}\n` +
       `\`\`\``
@@ -53,7 +54,10 @@ const NO_SCRIPTS_FOUND_ERROR = (params: FuncParameters): AgentFunctionResult => 
   ],
   messages: [
     ChatMessageBuilder.functionCall(FN_NAME, params),
-    ChatMessageBuilder.system(`Found no results for script '${params.namespace}'. Try creating the script instead.`),
+    ChatMessageBuilder.functionCallResult(
+      FN_NAME,
+      `Found no results for script '${params.namespace}'. Try creating the script instead.`
+    ),
   ]
 });
 const FIND_SCRIPT_TITLE = (params: FuncParameters) => `Searched for '${params.namespace}' script ("${params.description}")`;

--- a/packages/evo/src/agent-functions/index.ts
+++ b/packages/evo/src/agent-functions/index.ts
@@ -1,7 +1,7 @@
 import { createScript } from "./createScript";
 import { executeScript } from "./executeScript";
 import { findScript } from "./findScript";
-import { readVar } from "./readVar";
+import { readVariable } from "./readVariable";
 import { AgentContext } from "../AgentContext";
 import { AgentFunction } from "@evo-ninja/agent-utils";
 import { ScriptWriter } from "@evo-ninja/js-script-writer-agent";
@@ -11,6 +11,6 @@ export function agentFunctions(createScriptWriter: () => ScriptWriter): AgentFun
     createScript(createScriptWriter),
     executeScript,
     findScript,
-    readVar,
+    readVariable,
   ];
 }

--- a/packages/evo/src/agent-functions/readVariable.ts
+++ b/packages/evo/src/agent-functions/readVariable.ts
@@ -3,7 +3,7 @@ import { AgentFunction, AgentFunctionResult, AgentOutputType, ChatMessageBuilder
 import { AgentContext } from "../AgentContext";
 import { FUNCTION_CALL_FAILED, FUNCTION_CALL_SUCCESS_CONTENT } from "../prompts";
 
-const FN_NAME = "readVar";
+const FN_NAME = "readVariable";
 type FuncParameters = { 
   name: string,
   start: number,
@@ -26,7 +26,10 @@ const SUCCESS = (params: FuncParameters, varValue: string): AgentFunctionResult 
   ],
   messages: [
     ChatMessageBuilder.functionCall(FN_NAME, params),
-    ChatMessageBuilder.system(READ_GLOBAL_VAR_MESSAGE(params.name, varValue, params.start, params.count))
+    ChatMessageBuilder.functionCallResult(
+      FN_NAME,
+      READ_GLOBAL_VAR_MESSAGE(params.name, varValue, params.start, params.count)
+    )
   ]
 });
 const VAR_NOT_FOUND_ERROR = (params: FuncParameters): AgentFunctionResult => ({
@@ -39,7 +42,10 @@ const VAR_NOT_FOUND_ERROR = (params: FuncParameters): AgentFunctionResult => ({
   ],
   messages: [
     ChatMessageBuilder.functionCall(FN_NAME, params),
-    ChatMessageBuilder.system(FUNCTION_CALL_FAILED(params, FN_NAME, `Global variable {{${params.name}}} not found.`))
+    ChatMessageBuilder.functionCallResult(
+      FN_NAME,
+      `Error: Global variable {{${params.name}}} not found.`
+    )
   ]
 });
 
@@ -64,9 +70,9 @@ export const READ_GLOBAL_VAR_MESSAGE = (varName: string, value: string | undefin
   }
 };
 
-export const readVar: AgentFunction<AgentContext> = {
+export const readVariable: AgentFunction<AgentContext> = {
   definition: {
-    name: "readVar",
+    name: "readVariable",
     description: `Reads the stored global variable in JSON. If the JSON is longer than ${MAX_VAR_LENGTH} characters, it will be truncated`,
     parameters: {
       type: "object",

--- a/packages/evo/src/prompts.ts
+++ b/packages/evo/src/prompts.ts
@@ -10,7 +10,7 @@ Functionalities:
 findScript: I actively search and identify scripts that can be repurposed or combined for the current task.
 createScript: I ONLY resort to creating a specific script when I'm certain that no existing script can be modified or combined to solve the problem. I never create overly general or vague scripts.
 executeScript: I run scripts using TypeScript syntax. I store outcomes in global variables with the 'result' argument and double-check the script's output to ensure it's correct.
-readVar: I can access the JSON preview of a global variable. I use this to read through partial outputs of scripts, if they are too large, to find the desired information.
+readVariable: I can access the JSON preview of a global variable. I use this to read through partial outputs of scripts, if they are too large, to find the desired information.
 
 Feedback Scripts:
 agent.onGoalAchieved: I signal when a task has been successfully completed.

--- a/packages/js-script-writer/src/agent-functions/think.ts
+++ b/packages/js-script-writer/src/agent-functions/think.ts
@@ -21,6 +21,7 @@ const SUCCESS = (params: FuncParameters): AgentFunctionResult => ({
   ],
   messages: [
     ChatMessageBuilder.functionCall(FN_NAME, params),
+    ChatMessageBuilder.functionCallResult(FN_NAME, "Assistant, please respond."),
   ]
 });
 

--- a/packages/js-script-writer/src/agent-functions/writeFunction.ts
+++ b/packages/js-script-writer/src/agent-functions/writeFunction.ts
@@ -35,7 +35,7 @@ const SUCCESS = (params: FuncParameters): AgentFunctionResult => ({
   ],
   messages: [
     ChatMessageBuilder.functionCall(FN_NAME, params),
-    ChatMessageBuilder.system(`Success.`),
+    ChatMessageBuilder.functionCallResult(FN_NAME, "Success."),
   ]
 });
 const CANNOT_CREATE_IN_AGENT_NAMESPACE_ERROR = (params: FuncParameters): AgentFunctionResult => ({
@@ -48,8 +48,9 @@ const CANNOT_CREATE_IN_AGENT_NAMESPACE_ERROR = (params: FuncParameters): AgentFu
   ],
   messages: [
     ChatMessageBuilder.functionCall(FN_NAME, params),
-    ChatMessageBuilder.system(
-      `Failed writing the function.\n` +
+    ChatMessageBuilder.functionCallResult(
+      FN_NAME,
+      `Error: Failed writing the function.\n` +
       `Namespaces starting with 'agent.' are reserved.`
     ),
   ]
@@ -64,7 +65,9 @@ const CANNOT_REQUIRE_LIB_ERROR = (params: FuncParameters): AgentFunctionResult =
   ],
   messages: [
     ChatMessageBuilder.functionCall(FN_NAME, params),
-    ChatMessageBuilder.system(`Cannot require libraries other than ${allowedLibs.join(", ")}.`),
+    ChatMessageBuilder.functionCallResult(
+      FN_NAME, `Error: Cannot require libraries other than ${allowedLibs.join(", ")}.`
+    ),
   ]
 });
 

--- a/packages/subagents/src/__tests__/research-agent.spec.ts
+++ b/packages/subagents/src/__tests__/research-agent.spec.ts
@@ -20,7 +20,7 @@ dotenv.config({
   path: path.join(__dirname, "../../../../.env")
 });
 
-jest.setTimeout(120000);
+jest.setTimeout(300000);
 
 describe('Research Agent Test Suite', () => {
 
@@ -115,5 +115,17 @@ describe('Research Agent Test Suite', () => {
     const teslasRevenue = agent.workspace.readFileSync(generatedFiles[0]);
     expect(teslasRevenue).toBeTruthy();
     expect(teslasRevenue).toContain("81,462");
+  });
+
+  test.skip("revenue-retrieval-2", async () => {
+    const { agent, debugLog } = createResearchAgent("revenue-retrieval-2");
+    const response = await runResearchAgent(
+      agent,
+      "Write tesla's revenue every year since its creation into a .txt file. Use the US notation, with a precision rounded to the nearest million dollars (for instance, $31,578 million)..",
+      debugLog
+    );
+
+    expect(response.value.ok).toBe(true);
+    console.log(response)
   });
 });

--- a/packages/subagents/src/agents/DevAgent.ts
+++ b/packages/subagents/src/agents/DevAgent.ts
@@ -40,6 +40,15 @@ const AGENT_CONFIG: AgentConfig<DevAgentRunArgs> = {
           }
         ],
         messages: []
+      }),
+      fail: (agentName: string, functionName: string, _: any, error: string) => ({
+        outputs: [
+          {
+            type: AgentOutputType.Error,
+            title: `[${agentName}] Error onGoalAchieved: ${error}`
+          }
+        ],
+        messages: []
       })
     },
     agent_onGoalFailed: {
@@ -54,6 +63,15 @@ const AGENT_CONFIG: AgentConfig<DevAgentRunArgs> = {
           {
             type: AgentOutputType.Error,
             title: `[${agentName}] ${functionName}`
+          }
+        ],
+        messages: []
+      }),
+      fail: (agentName: string, functionName: string, _: any, error: string) => ({
+        outputs: [
+          {
+            type: AgentOutputType.Error,
+            title: `[${agentName}] Error onGoalFailed: ${error}`
           }
         ],
         messages: []
@@ -93,6 +111,20 @@ const AGENT_CONFIG: AgentConfig<DevAgentRunArgs> = {
         ],
         messages: [
           ChatMessageBuilder.functionCall(functionName, params, result),
+        ]
+      }),
+      fail: (agentName: string, functionName: string, params: any, error: string) => ({
+        outputs: [
+          {
+            type: AgentOutputType.Error,
+            title: `[${agentName}] ${functionName}`,
+            content:`${params.path}\n` +
+            `${params.encoding}\n` +
+            `${trimText(error, 200)}`
+          }
+        ],
+        messages: [
+          ChatMessageBuilder.functionCall(functionName, params, error),
         ]
       }),
       isTermination: false,

--- a/packages/subagents/src/agents/DevAgent.ts
+++ b/packages/subagents/src/agents/DevAgent.ts
@@ -111,7 +111,7 @@ const AGENT_CONFIG: AgentConfig<DevAgentRunArgs> = {
         ],
         messages: [
           ChatMessageBuilder.functionCall(functionName, params),
-          ChatMessageBuilder.functionCallResponse(functionName, result)
+          ChatMessageBuilder.functionCallResult(functionName, result)
         ]
       }),
       fail: (agentName: string, functionName: string, params: any, error: string) => ({
@@ -126,8 +126,7 @@ const AGENT_CONFIG: AgentConfig<DevAgentRunArgs> = {
         ],
         messages: [
           ChatMessageBuilder.functionCall(functionName, params),
-          ChatMessageBuilder.functionCallResponse(functionName, error),
-          
+          ChatMessageBuilder.functionCallResult(functionName, `Error: ${error}`)
         ]
       }),
       isTermination: false,

--- a/packages/subagents/src/agents/DevAgent.ts
+++ b/packages/subagents/src/agents/DevAgent.ts
@@ -99,7 +99,7 @@ const AGENT_CONFIG: AgentConfig<DevAgentRunArgs> = {
         path: string;
         data: string;
         encoding: string;
-      }, result?: string) => ({
+      }, result: string) => ({
         outputs: [
           {
             type: AgentOutputType.Success,
@@ -110,7 +110,8 @@ const AGENT_CONFIG: AgentConfig<DevAgentRunArgs> = {
           }
         ],
         messages: [
-          ChatMessageBuilder.functionCall(functionName, params, result),
+          ChatMessageBuilder.functionCall(functionName, params),
+          ChatMessageBuilder.functionCallResponse(functionName, result)
         ]
       }),
       fail: (agentName: string, functionName: string, params: any, error: string) => ({
@@ -124,7 +125,9 @@ const AGENT_CONFIG: AgentConfig<DevAgentRunArgs> = {
           }
         ],
         messages: [
-          ChatMessageBuilder.functionCall(functionName, params, error),
+          ChatMessageBuilder.functionCall(functionName, params),
+          ChatMessageBuilder.functionCallResponse(functionName, error),
+          
         ]
       }),
       isTermination: false,

--- a/packages/subagents/src/agents/DevAgent.ts
+++ b/packages/subagents/src/agents/DevAgent.ts
@@ -81,7 +81,7 @@ const AGENT_CONFIG: AgentConfig<DevAgentRunArgs> = {
         path: string;
         data: string;
         encoding: string;
-      }) => ({
+      }, result?: string) => ({
         outputs: [
           {
             type: AgentOutputType.Success,
@@ -92,7 +92,7 @@ const AGENT_CONFIG: AgentConfig<DevAgentRunArgs> = {
           }
         ],
         messages: [
-          ChatMessageBuilder.functionCall(functionName, params),
+          ChatMessageBuilder.functionCall(functionName, params, result),
         ]
       }),
       isTermination: false,

--- a/packages/subagents/src/agents/ResearchAgent.ts
+++ b/packages/subagents/src/agents/ResearchAgent.ts
@@ -100,7 +100,7 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
         ],
         messages: [
           ChatMessageBuilder.functionCall(functionName, params),
-          ChatMessageBuilder.functionCallResponse(functionName, result)
+          ChatMessageBuilder.functionCallResult(functionName, result)
         ]
       }),
       fail: (agentName: string, functionName: string, params: any, error: string) => ({
@@ -112,7 +112,7 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
         ],
         messages: [
           ChatMessageBuilder.functionCall(functionName, params),
-          ChatMessageBuilder.functionCallResponse(functionName, error)
+          ChatMessageBuilder.functionCallResult(functionName, `Error: ${error}`)
         ]
       }),
       isTermination: false,
@@ -138,8 +138,8 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
           }
         ],
         messages: [
-          ChatMessageBuilder.functionCall(functionName, params, result),
-          ChatMessageBuilder.functionCallResponse(functionName, result)
+          ChatMessageBuilder.functionCall(functionName, params),
+          ChatMessageBuilder.functionCallResult(functionName, result)
         ]
       }),
       fail: (agentName: string, functionName: string, params: any, error: string) => ({
@@ -151,7 +151,7 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
         ],
         messages: [
           ChatMessageBuilder.functionCall(functionName, params),
-          ChatMessageBuilder.functionCallResponse(functionName, error)
+          ChatMessageBuilder.functionCallResult(functionName, `Error: ${error}`)
         ]
       }),
       isTermination: false,
@@ -178,7 +178,7 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
         ],
         messages: [
           ChatMessageBuilder.functionCall(functionName, params),
-          ChatMessageBuilder.functionCallResponse(functionName, result)
+          ChatMessageBuilder.functionCallResult(functionName, result)
         ]
       }),
       fail: (agentName: string, functionName: string, params: any, error: string) => ({
@@ -190,7 +190,7 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
         ],
         messages: [
           ChatMessageBuilder.functionCall(functionName, params),
-          ChatMessageBuilder.functionCallResponse(functionName, error)
+          ChatMessageBuilder.functionCallResult(functionName, `Error: ${error}`)
         ]
       }),
       isTermination: false,
@@ -228,8 +228,8 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
           }
         ],
         messages: [
-          ChatMessageBuilder.functionCall(functionName, params, result),
-          ChatMessageBuilder.functionCallResponse(functionName, result),
+          ChatMessageBuilder.functionCall(functionName, params),
+          ChatMessageBuilder.functionCallResult(functionName, result)
         ]
       }),
       fail: (agentName: string, functionName: string, params: any, error: string) => ({
@@ -241,7 +241,7 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
         ],
         messages: [
           ChatMessageBuilder.functionCall(functionName, params),
-          ChatMessageBuilder.functionCallResponse(functionName, error)
+          ChatMessageBuilder.functionCallResult(functionName, `Error: ${error}`)
         ]
       }),
       isTermination: false,

--- a/packages/subagents/src/agents/ResearchAgent.ts
+++ b/packages/subagents/src/agents/ResearchAgent.ts
@@ -98,7 +98,7 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
         required: ["query"],
         additionalProperties: false
       },
-      success: (agentName: string, functionName: string, params: { url: string }) => ({
+      success: (agentName: string, functionName: string, params: { url: string }, result?: string) => ({
         outputs: [
           {
             type: AgentOutputType.Success,
@@ -107,7 +107,7 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
           }
         ],
         messages: [
-          ChatMessageBuilder.functionCall(functionName, params),
+          ChatMessageBuilder.functionCall(functionName, params, result),
         ]
       }),
       isTermination: false,
@@ -124,7 +124,7 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
         required: ["query"],
         additionalProperties: false
       },
-      success: (agentName: string, functionName: string, params: { url: string }) => ({
+      success: (agentName: string, functionName: string, params: { url: string }, result?: string) => ({
         outputs: [
           {
             type: AgentOutputType.Success,
@@ -133,7 +133,7 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
           }
         ],
         messages: [
-          ChatMessageBuilder.functionCall(functionName, params),
+          ChatMessageBuilder.functionCall(functionName, params, result),
         ]
       }),
       isTermination: false,
@@ -160,7 +160,7 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
         path: string;
         data: string;
         encoding: string;
-      }) => ({
+      }, result) => ({
         outputs: [
           {
             type: AgentOutputType.Success,
@@ -171,7 +171,7 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
           }
         ],
         messages: [
-          ChatMessageBuilder.functionCall(functionName, params),
+          ChatMessageBuilder.functionCall(functionName, params, result),
         ]
       }),
       isTermination: false,

--- a/packages/subagents/src/agents/ResearchAgent.ts
+++ b/packages/subagents/src/agents/ResearchAgent.ts
@@ -41,6 +41,15 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
           }
         ],
         messages: []
+      }),
+      fail: (agentName: string, functionName: string, _: any, error: string) => ({
+        outputs: [
+          {
+            type: AgentOutputType.Error,
+            title: `[${agentName}] Error in ${functionName}: ${error}`
+          }
+        ],
+        messages: []
       })
     },
     agent_onGoalFailed: {
@@ -58,6 +67,15 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
           }
         ],
         messages: []
+      }),
+      fail: (agentName: string, functionName: string, _: any, error: string) => ({
+        outputs: [
+          {
+            type: AgentOutputType.Error,
+            title: `[${agentName}] Error in ${functionName}: ${error}`
+          }
+        ],
+        messages: []
       })
     },
     web_search: {
@@ -72,7 +90,7 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
         required: ["query"],
         additionalProperties: false
       },
-      success: (agentName: string, functionName: string, params: { query: string }) => ({
+      success: (agentName: string, functionName: string, params: { query: string }, result: string) => ({
         outputs: [
           {
             type: AgentOutputType.Success,
@@ -81,7 +99,18 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
           }
         ],
         messages: [
-          ChatMessageBuilder.functionCall(functionName, params),
+          ChatMessageBuilder.functionCall(functionName, params, result),
+        ]
+      }),
+      fail: (agentName: string, functionName: string, params: any, error: string) => ({
+        outputs: [
+          {
+            type: AgentOutputType.Error,
+            title: `[${agentName}] Error in ${functionName}: ${error}`
+          }
+        ],
+        messages: [
+          ChatMessageBuilder.functionCall(functionName, params, error),
         ]
       }),
       isTermination: false,
@@ -110,6 +139,17 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
           ChatMessageBuilder.functionCall(functionName, params, result),
         ]
       }),
+      fail: (agentName: string, functionName: string, params: any, error: string) => ({
+        outputs: [
+          {
+            type: AgentOutputType.Error,
+            title: `[${agentName}] Error in ${functionName}: ${error}`
+          }
+        ],
+        messages: [
+          ChatMessageBuilder.functionCall(functionName, params, error),
+        ]
+      }),
       isTermination: false,
     },
     web_scrapeLinks: {
@@ -134,6 +174,17 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
         ],
         messages: [
           ChatMessageBuilder.functionCall(functionName, params, result),
+        ]
+      }),
+      fail: (agentName: string, functionName: string, params: any, error: string) => ({
+        outputs: [
+          {
+            type: AgentOutputType.Error,
+            title: `[${agentName}] Error in ${functionName}: ${error}`
+          }
+        ],
+        messages: [
+          ChatMessageBuilder.functionCall(functionName, params, error),
         ]
       }),
       isTermination: false,
@@ -172,6 +223,17 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
         ],
         messages: [
           ChatMessageBuilder.functionCall(functionName, params, result),
+        ]
+      }),
+      fail: (agentName: string, functionName: string, params: any, error: string) => ({
+        outputs: [
+          {
+            type: AgentOutputType.Error,
+            title: `[${agentName}] Error in ${functionName}: ${error}`
+          }
+        ],
+        messages: [
+          ChatMessageBuilder.functionCall(functionName, params, error),
         ]
       }),
       isTermination: false,

--- a/packages/subagents/src/agents/ResearchAgent.ts
+++ b/packages/subagents/src/agents/ResearchAgent.ts
@@ -99,7 +99,8 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
           }
         ],
         messages: [
-          ChatMessageBuilder.functionCall(functionName, params, result),
+          ChatMessageBuilder.functionCall(functionName, params),
+          ChatMessageBuilder.functionCallResponse(functionName, result)
         ]
       }),
       fail: (agentName: string, functionName: string, params: any, error: string) => ({
@@ -110,7 +111,8 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
           }
         ],
         messages: [
-          ChatMessageBuilder.functionCall(functionName, params, error),
+          ChatMessageBuilder.functionCall(functionName, params),
+          ChatMessageBuilder.functionCallResponse(functionName, error)
         ]
       }),
       isTermination: false,
@@ -127,7 +129,7 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
         required: ["query"],
         additionalProperties: false
       },
-      success: (agentName: string, functionName: string, params: { url: string }, result?: string) => ({
+      success: (agentName: string, functionName: string, params: { url: string }, result: string) => ({
         outputs: [
           {
             type: AgentOutputType.Success,
@@ -137,6 +139,7 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
         ],
         messages: [
           ChatMessageBuilder.functionCall(functionName, params, result),
+          ChatMessageBuilder.functionCallResponse(functionName, result)
         ]
       }),
       fail: (agentName: string, functionName: string, params: any, error: string) => ({
@@ -147,7 +150,8 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
           }
         ],
         messages: [
-          ChatMessageBuilder.functionCall(functionName, params, error),
+          ChatMessageBuilder.functionCall(functionName, params),
+          ChatMessageBuilder.functionCallResponse(functionName, error)
         ]
       }),
       isTermination: false,
@@ -164,7 +168,7 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
         required: ["query"],
         additionalProperties: false
       },
-      success: (agentName: string, functionName: string, params: { url: string }, result?: string) => ({
+      success: (agentName: string, functionName: string, params: { url: string }, result: string) => ({
         outputs: [
           {
             type: AgentOutputType.Success,
@@ -173,7 +177,8 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
           }
         ],
         messages: [
-          ChatMessageBuilder.functionCall(functionName, params, result),
+          ChatMessageBuilder.functionCall(functionName, params),
+          ChatMessageBuilder.functionCallResponse(functionName, result)
         ]
       }),
       fail: (agentName: string, functionName: string, params: any, error: string) => ({
@@ -184,7 +189,8 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
           }
         ],
         messages: [
-          ChatMessageBuilder.functionCall(functionName, params, error),
+          ChatMessageBuilder.functionCall(functionName, params),
+          ChatMessageBuilder.functionCallResponse(functionName, error)
         ]
       }),
       isTermination: false,
@@ -211,7 +217,7 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
         path: string;
         data: string;
         encoding: string;
-      }, result) => ({
+      }, result: string) => ({
         outputs: [
           {
             type: AgentOutputType.Success,
@@ -223,6 +229,7 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
         ],
         messages: [
           ChatMessageBuilder.functionCall(functionName, params, result),
+          ChatMessageBuilder.functionCallResponse(functionName, result),
         ]
       }),
       fail: (agentName: string, functionName: string, params: any, error: string) => ({
@@ -233,7 +240,8 @@ export const AGENT_CONFIG: AgentConfig<ResearchAgentRunArgs> = {
           }
         ],
         messages: [
-          ChatMessageBuilder.functionCall(functionName, params, error),
+          ChatMessageBuilder.functionCall(functionName, params),
+          ChatMessageBuilder.functionCallResponse(functionName, error)
         ]
       }),
       isTermination: false,


### PR DESCRIPTION
when executing the `scriptExecutor` function we're not passing back the result to the message context - inspired from the [example from open ai docs](https://platform.openai.com/docs/guides/gpt/function-calling), the best practice is to pass the content in the function call again