### PR TITLE
Benchmarks: CombineCsv

### DIFF
--- a/scripts/csv.join.js
+++ b/scripts/csv.join.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+
+const csv1 = fs.readFileSync(csv1Path, 'utf8').trim().split('\n');
+const csv2 = fs.readFileSync(csv2Path, 'utf8').trim().split('\n');
+
+const headers1 = csv1[0].split(',');
+const headers2 = csv2[0].split(',');
+
+const idx1 = headers1.indexOf(commonColumn);
+const idx2 = headers2.indexOf(commonColumn);
+
+const map2 = new Map(csv2.slice(1).map(row => [row.split(',')[idx2], row]));
+
+const mergedData = csv1.slice(1).map(row1 => {
+  const key = row1.split(',')[idx1];
+  const row2 = map2.get(key) || Array(headers2.length).fill('').join(',');
+  return row1 + ',' + row2.split(',').slice(1).join(',');
+});
+
+const mergedCSV = [headers1.concat(headers2.slice(1)).join(','), ...mergedData].join('\n');
+
+fs.writeFileSync(outputPath, mergedCSV);

--- a/scripts/csv.join.json
+++ b/scripts/csv.join.json
@@ -1,0 +1,6 @@
+{
+  "name": "csv.join",
+  "description": "Reads two CSV files, merges them based on a common column, and writes the resulting data table to a new CSV file. The merged table retains all columns from both original tables.",
+  "arguments": "{ csv1Path: string, csv2Path: string, commonColumn: string, outputPath: string }",
+  "code": "./csv.join.js"
+}

--- a/scripts/csv.parse.js
+++ b/scripts/csv.parse.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+
+const csvData = fs.readFileSync(inputPath, 'utf8');
+const lines = csvData.split('\n');
+const headers = lines[0].split(',');
+
+const jsonOutput = lines.slice(1).map(line => {
+  const values = line.split(',');
+  return headers.reduce((acc, header, index) => {
+    acc[header] = values[index];
+    return acc;
+  }, {});
+});
+
+return JSON.stringify(jsonOutput);

--- a/scripts/csv.parse.json
+++ b/scripts/csv.parse.json
@@ -1,0 +1,6 @@
+{
+  "name": "csv.parse",
+  "description": "Parses a CSV file and returns a JSON string representing its contents. The JSON is an array of objects, each of which represents a table row, with headers as keys and data points as values.",
+  "arguments": "{ inputPath: string }",
+  "code": "./csv.parse.js"
+}

--- a/scripts/csv.sortColumns.js
+++ b/scripts/csv.sortColumns.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const util = require('util');
+
+// Read the CSV file
+const data = fs.readFileSync(inputPath, 'utf8');
+
+// Parse the CSV data into a 2D array
+let rows = data.split('\n').map(row => row.split(','));
+
+// Transpose the array
+let transposed = rows[0].map((col, i) => rows.map(row => row[i]));
+
+// Sort the 'columns' (which are now rows)
+transposed.sort();
+
+// Transpose the array back to its original format
+rows = transposed[0].map((col, i) => transposed.map(row => row[i]));
+
+// Convert the sorted data back into CSV format
+const sortedData = rows.map(row => row.join(',')).join('\n');
+
+// Write the sorted data to the output file
+fs.writeFileSync(outputPath, sortedData, 'utf8');

--- a/scripts/csv.sortColumns.json
+++ b/scripts/csv.sortColumns.json
@@ -1,0 +1,6 @@
+{
+  "name": "csv.sortColumns",
+  "description": "Sorts the columns of a CSV file alphabetically and writes the sorted data to a new CSV file.",
+  "arguments": "{ inputPath: string, outputPath: string }",
+  "code": "./csv.sortColumns.js"
+}


### PR DESCRIPTION
Added scripts to help Evo combine and sort csv files.

The scripts are:
 - `csv.join` reads two csv files, merges them on a common column, and prints result to a file
- `csv.sortColumn`- sorts columns of a csv file alphabetically and prints results to a file
- `csv.parse` - parses csv file to a json string

I wrote `csv.join` and `csv.parse`. Evo wrote `csv.sortColumn`. 

The `csv.parse` script is not used for this benchmark task, but Evo kept wanting to (and failing to) parse the csv content as JSON before I added the `csv.join` script. I kept the `csv.parse` script in case it helps with unknown benchmarks in the future.

The task is `The csvs 'file1.csv' and 'file2.csv' both have a column 'ID'. Combine these 2 csvs using the 'ID' column. Sort the rows by ID in ascending order and the columns alphabetically. Write the output in output.csv`

With the additional scripts, Evo correctly finds and executes the three scripts needed to merge the csv files, sort the columns, and sort the rows.

Closes https://github.com/polywrap/evo.ninja/issues/256