### PR TITLE
chore(cli): add task arg

### DIFF
--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -10,6 +10,7 @@ export async function cli(): Promise<void> {
     .option("-r, --root <path>")
     .option("-d, --debug")
     .option("-m, --messages <path>")
+    .option("--task <number>")
     .parse();
 
   const options = program.opts();
@@ -26,7 +27,8 @@ export async function cli(): Promise<void> {
     timeout,
     rootDir: options.root,
     debug: options.debug,
-    messagesPath: options.messages
+    messagesPath: options.messages,
+    taskId: options.task
   });
 
   await app.logger.logHeader();


### PR DESCRIPTION
now we can use `yarn start --task 123` to define a static workspace. this allows us to run evo with previous messages (using the `-m` flag) and also make sure that we can previously add artifacts to this

`yarn start --task 123 -m msgs.json -d`