### PR TITLE
feat: sessions + .evo directory refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build
 debug
 coverage
 workspace
+sessions
 chats
 .logs
 .tests

--- a/apps/cli/src/api.ts
+++ b/apps/cli/src/api.ts
@@ -15,7 +15,7 @@ const rootDir = path.resolve(
   path.join(__dirname, "../../../")
 );
 
-const workspaceDir = process.env.AGENT_WORKSPACE || path.join(rootDir, "workspace");
+const sessionsDir = process.env.AGENT_WORKSPACE || path.join(rootDir, "sessions");
 
 const options = program
   .option("-c, --clean")
@@ -44,13 +44,13 @@ async function taskHandler(
   input: TaskInput | null
 ): Promise<StepHandler> {
 
-  const workspace = new AgentProtocolWorkspace(
-    path.join(workspaceDir, id)
+  const userWorkspace = new AgentProtocolWorkspace(
+    path.join(sessionsDir, id)
   );
   const app = createApp({
     rootDir,
-    userWorkspace: workspace,
-    taskId: id,
+    userWorkspace,
+    sessionName: id,
     debug: true,
   });
 
@@ -78,9 +78,9 @@ async function taskHandler(
         ? response.value.message
         : "No Message";
 
-    workspace.writeArtifacts();
-    const artifacts = workspace.getArtifacts();
-    workspace.cleanArtifacts();
+    userWorkspace.writeArtifacts();
+    const artifacts = userWorkspace.getArtifacts();
+    userWorkspace.cleanArtifacts();
 
     if (response.done) {
       if (!response.value.ok) {
@@ -112,5 +112,5 @@ async function taskHandler(
   return stepHandler;
 }
 Agent.handleTask(taskHandler, {
-  workspace: workspaceDir
+  workspace: sessionsDir
 }).start();

--- a/apps/cli/src/app.ts
+++ b/apps/cli/src/app.ts
@@ -45,12 +45,12 @@ export interface App {
 }
 
 export interface AppConfig {
-  rootDir?: string;
+  sessionName?: string;
   timeout?: Timeout;
-  userWorkspace?: Workspace;
+  rootDir?: string;
   debug?: boolean;
-  taskId?: string;
   messagesPath?: string;
+  userWorkspace?: Workspace;
 }
 
 const getMessagesFromPath = (path: string): { type: ChatLogType, msgs: ChatMessage[]}[] => {
@@ -68,15 +68,19 @@ export function createApp(config?: AppConfig): App {
     : path.join(__dirname, "../../../");
 
   const date = new Date();
-  const defaultId = `${date.getFullYear()}-${
+  const defaultSessionName = `${date.getFullYear()}-${
     date.getMonth() + 1
   }-${date.getDate()}_${date.getHours()}-${date.getMinutes()}-${date.getSeconds()}`;
-  const taskId = config?.taskId ?? defaultId;
+  const sessionName = config?.sessionName ?? defaultSessionName;
   const env = new Env(process.env as Record<string, string>);
-  const workspacePath = path.join(rootDir, "workspace", taskId);
+  const workspacePath = path.join(rootDir, "sessions", sessionName);
+
+  // .evo directory
+  const evoInternalsPath = path.join(workspacePath, ".evo");
+  const evoInternalsWorkspace = new FileSystemWorkspace(evoInternalsPath);
+
   // Chat Log File
-  const logWorkspace = new FileSystemWorkspace(workspacePath);
-  const fileLogger = new FileLogger(logWorkspace.toWorkspacePath("chat.md"));
+  const fileLogger = new FileLogger(evoInternalsWorkspace.toWorkspacePath("chat.md"));
 
   // Logger
   const consoleLogger = new ConsoleLogger();
@@ -122,9 +126,7 @@ export function createApp(config?: AppConfig): App {
   let debugLog: DebugLog | undefined;
 
   if (config?.debug) {
-    debugLog = new DebugLog(
-      new FileSystemWorkspace(workspacePath)
-    );
+    debugLog = new DebugLog(evoInternalsWorkspace);
 
     // Wrap the LLM API
     llm = new DebugLlmApi(debugLog, llm);

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -6,11 +6,11 @@ import { program } from "commander";
 export async function cli(): Promise<void> {
   program
     .argument("[goal]", "Goal to be achieved")
+    .option("-s, --session <name>")
     .option("-t, --timeout <seconds>")
     .option("-r, --root <path>")
     .option("-d, --debug")
     .option("-m, --messages <path>")
-    .option("--task <number>")
     .parse();
 
   const options = program.opts();
@@ -28,7 +28,7 @@ export async function cli(): Promise<void> {
     rootDir: options.root,
     debug: options.debug,
     messagesPath: options.messages,
-    taskId: options.task
+    sessionName: options.session
   });
 
   await app.logger.logHeader();

--- a/packages/agent-utils-fs/src/FileSystemWorkspace.ts
+++ b/packages/agent-utils-fs/src/FileSystemWorkspace.ts
@@ -66,6 +66,7 @@ export class FileSystemWorkspace implements Workspace {
   readdirSync(subpath: string): DirectoryEntry[] {
     const absPath = this.toWorkspacePath(subpath);
     return fs.readdirSync(absPath, { withFileTypes: true })
+      .filter((d) => !d.name.startsWith("."))
       .map((d) => ({ name: d.name, type: d.isDirectory() ? "directory" : "file" }));
   }
 

--- a/packages/agent-utils/src/sys/workspaces/InMemoryWorkspace.ts
+++ b/packages/agent-utils/src/sys/workspaces/InMemoryWorkspace.ts
@@ -25,7 +25,8 @@ export class InMemoryWorkspace implements Workspace {
   }
 
   readdirSync(subpath: string): DirectoryEntry[] {
-    return this.fs.readdirSync(subpath);
+    return this.fs.readdirSync(subpath)
+      .filter((d) => !d.name.startsWith("."));
   }
 
   appendFileSync(subpath: string, data: string): void {


### PR DESCRIPTION
Refactored the `workspace/` directory to be:
```
sessions/
  <session-name>/
    .evo/
      debug.json
    user-file.txt
    output.txt
```

Additionally the `Workspace` implementations ignore this `.evo` directory when `readdir` is called.