### PR TITLE
Search with surroundings

### DIFF
--- a/packages/agent-utils/src/__tests__/chunker.spec.ts
+++ b/packages/agent-utils/src/__tests__/chunker.spec.ts
@@ -33,20 +33,18 @@ describe("Chunker", () => {
     const chunks = TextChunker.fixedCharacterLength(text, { chunkLength: 100, overlap: 0 });
     const collection = db.addCollection('chars')
     await collection.add(chunks)
-    const searchResults = await collection.search(query)
-    const results = searchResults.slice(0, 3);
+    const searchResults = await collection.search(query, 3)
 
-    console.log(`CHARS: ${JSON.stringify(results.map(s => s.text()), null, 2)}`)
+    console.log(`CHARS: ${JSON.stringify(searchResults.map(s => s.text()), null, 2)}`)
   })
 
   test("Characters-based with overlap", async () => {
     const chunks = TextChunker.fixedCharacterLength(text, { chunkLength: 100, overlap: 15 });
     const collection = db.addCollection('charsoverlap')
     await collection.add(chunks)
-    const searchResults = await collection.search(query)
-    const results = searchResults.slice(0, 3);
+    const searchResults = await collection.search(query, 3)
 
-    console.log(`CHARS OVERLAP: ${JSON.stringify(results.map(s => s.text()), null, 2)}`)
+    console.log(`CHARS OVERLAP: ${JSON.stringify(searchResults.map(s => s.text()), null, 2)}`)
   })
 
   test("Parent-doc-retrieval - Parent Sentences; Child Characters", async () => {
@@ -59,10 +57,9 @@ describe("Chunker", () => {
     const collection = db.addCollection('parentdocs') as LocalCollection<{ parent: string; index: number }>
     await collection.add(docs, metadatas.map(({ parent }, index) => ({ parent, index })))
 
-    const searchResults = await collection.search(query)
-    const results = searchResults.slice(0, 3);
+    const searchResults = await collection.search(query, 3)
 
-    const pdrResults = results.map(s => ({
+    const pdrResults = searchResults.map(s => ({
       text: s.text(),
       parent: s.metadata()?.parent
     }))
@@ -78,10 +75,11 @@ describe("Chunker", () => {
 
     const searchResults = await collection.searchWithSurroundingContext(query, {
       surroundingCharacters: 500,
-      overlap: 15
+      overlap: 15,
+      limit: 3
     })
 
-    console.log(`Surrounding: ${JSON.stringify(searchResults.slice(0, 3).map(r => ({
+    console.log(`Surrounding: ${JSON.stringify(searchResults.map(r => ({
       text: r.match.text(),
       surrounding: r.withSurrounding,
     })), null, 2)}`)

--- a/packages/agent-utils/src/chunking/utils.ts
+++ b/packages/agent-utils/src/chunking/utils.ts
@@ -1,0 +1,51 @@
+export const getTextFromPriorChunks = (args: { sortedElements: { text: () => string }[], currentIndex: number, overlap: number, characterLimit: number}) => {
+  const { sortedElements, currentIndex, overlap, characterLimit } = args
+  
+  let textBehind = ""
+
+  for (let i = currentIndex - 1; i >= 0; i--) {
+    const prevResult = sortedElements[i]
+
+    if (!prevResult || textBehind.length > characterLimit) {
+      return textBehind
+    }
+
+    const prevResultText = overlap ? prevResult.text().slice(0, -overlap) : prevResult.text()
+
+    if (prevResultText.length + textBehind.length <= characterLimit) {
+      textBehind = prevResultText + textBehind
+    } else {
+      const charactersLeft = characterLimit - textBehind.length
+      const prevResultPiece = prevResultText.slice(-charactersLeft)
+      textBehind = prevResultPiece + textBehind
+    }
+  }
+
+  return textBehind
+}
+
+export const getTextFromNextChunks = (args: { sortedElements: { text: () => string }[], currentIndex: number, overlap: number, characterLimit: number}) => {
+  const { sortedElements, currentIndex, overlap, characterLimit } = args
+  
+  let textForward = ""
+
+  for (let i = currentIndex + 1; i <= sortedElements.length; i++) {
+    const nextResult = sortedElements[i]
+
+    if (!nextResult || textForward.length > characterLimit) {
+      return textForward
+    }
+
+    const nextResultText = overlap ? nextResult.text().slice(overlap) : nextResult.text()
+
+    if (nextResultText.length + textForward.length <= characterLimit) {
+      textForward = textForward + nextResultText
+    } else {
+      const charactersLeft = characterLimit - textForward.length
+      const nextResultPiece = nextResultText.slice(-charactersLeft)
+      textForward = textForward + nextResultPiece
+    }
+  }
+
+  return textForward
+}

--- a/packages/agent-utils/src/embeddings/LocalCollection.ts
+++ b/packages/agent-utils/src/embeddings/LocalCollection.ts
@@ -67,8 +67,8 @@ export class LocalCollection<TMetadata extends BaseDocumentMetadata = BaseDocume
     return limit ? results.slice(0, limit) : results;
   }
 
-  async searchWithSurroundingContext(query: string, opts: { surroundingCharacters: number, overlap?: number }) {
-    const { surroundingCharacters, overlap } = opts;
+  async searchWithSurroundingContext(query: string, opts: { surroundingCharacters: number, overlap?: number, limit?: number }) {
+    const { surroundingCharacters, overlap, limit } = opts;
     const halfSurroundChars = Math.floor(surroundingCharacters / 2);
     
     const results = await this.search(query);
@@ -100,7 +100,7 @@ export class LocalCollection<TMetadata extends BaseDocumentMetadata = BaseDocume
       }
     })
 
-    return surroundedResults;
+    return limit ? surroundedResults.slice(0, limit) : surroundedResults;
   }
 
   async searchUnique(query: string, limit: number): Promise<LocalDocument<TMetadata>[]> {

--- a/packages/agent-utils/src/embeddings/LocalCollection.ts
+++ b/packages/agent-utils/src/embeddings/LocalCollection.ts
@@ -1,11 +1,12 @@
 import { EmbeddingApi } from "./EmbeddingApi";
 import { normalize, normalizedCosineSimilarity } from "./utils";
 import { LocalDocumentStore } from "./LocalDocumentStore";
-import { LocalDocument } from "./LocalDocument";
+import { BaseDocumentMetadata, LocalDocument } from "./LocalDocument";
 import { Workspace } from "../sys";
 import path from "path-browserify";
+import { getTextFromNextChunks, getTextFromPriorChunks } from "../chunking/utils";
 
-export class LocalCollection<TMetadata = unknown> {
+export class LocalCollection<TMetadata extends BaseDocumentMetadata = BaseDocumentMetadata> {
   private documentStore: LocalDocumentStore<TMetadata>;
 
   constructor(
@@ -42,29 +43,64 @@ export class LocalCollection<TMetadata = unknown> {
     }
   }
 
-  async search(query: string, limit: number): Promise<LocalDocument<TMetadata>[]> {
+  async search(query: string, limit?: number): Promise<LocalDocument<TMetadata>[]> {
     const queryEmbeddingResults = await this.embeddingApi.createEmbeddings(query);
     const queryVector = queryEmbeddingResults[0].embedding;
     const normalizedQueryVector = normalize(queryVector);
 
     const documents = this.documentStore.list();
 
-    const distances = documents.map(document => {
+    const scores = documents.map(document => {
       const vector = document.vector();
       const normalizedVector = normalize(vector);
 
-      const distance = normalizedCosineSimilarity(queryVector, normalizedQueryVector, vector, normalizedVector);
-      return { document, distance };
+      const score = normalizedCosineSimilarity(queryVector, normalizedQueryVector, vector, normalizedVector);
+      return { document, score };
     })
 
-    const sortedDistances = distances.sort((a, b) => b.distance - a.distance);
-    const topDistances = limit < 0 ? sortedDistances : sortedDistances.slice(0, limit);
+    const sortedScores = scores.sort((a, b) => b.score - a.score);
 
-    const results = topDistances.map(({ document }) => {
+    const results = sortedScores.map(({ document }) => {
       return document
     })
 
-    return results;
+    return limit ? results.slice(0, limit) : results;
+  }
+
+  async searchWithSurroundingContext(query: string, opts: { surroundingCharacters: number, overlap?: number }) {
+    const { surroundingCharacters, overlap } = opts;
+    const halfSurroundChars = Math.floor(surroundingCharacters / 2);
+    
+    const results = await this.search(query);
+
+    const resultsSortedByIndex = this.sortDocumentsByIndex(results);
+
+    const surroundedResults = results.map(result => {
+      const resultIndex = result.metadata()!.index;
+
+      const textBehind = getTextFromPriorChunks({
+        sortedElements: resultsSortedByIndex,
+        currentIndex: resultIndex,
+        overlap: overlap ?? 0,
+        characterLimit: halfSurroundChars
+      })
+
+      const textForward = getTextFromNextChunks({
+        sortedElements: resultsSortedByIndex,
+        currentIndex: resultIndex,
+        overlap: overlap ?? 0,
+        characterLimit: halfSurroundChars
+      })
+
+      const withSurrounding = [textBehind, result.text(), textForward].join("")
+
+      return {
+        match: result,
+        withSurrounding
+      }
+    })
+
+    return surroundedResults;
   }
 
   async searchUnique(query: string, limit: number): Promise<LocalDocument<TMetadata>[]> {
@@ -74,21 +110,21 @@ export class LocalCollection<TMetadata = unknown> {
 
     const documents = this.documentStore.list();
 
-    const distances = documents.map(document => {
+    const scores = documents.map(document => {
       const vector = document.vector();
       const normalizedVector = normalize(vector);
 
-      const distance = normalizedCosineSimilarity(queryVector, normalizedQueryVector, vector, normalizedVector);
-      return { document, distance, text: document.text() };
+      const score = normalizedCosineSimilarity(queryVector, normalizedQueryVector, vector, normalizedVector);
+      return { document, score, text: document.text() };
     })
 
-    const sortedDistances = [...new Map(distances.map(x =>
+    const sortedScores = [...new Map(scores.map(x =>
       [x.text, x])).values()]
-      .sort((a, b) => b.distance - a.distance);
+      .sort((a, b) => b.score - a.score);
     
-    const topDistances = sortedDistances.slice(0, limit);
+    const topScores = sortedScores.slice(0, limit);
 
-    const results = topDistances.map(({ document }) => {
+    const results = topScores.map(({ document }) => {
       return document
     })
 
@@ -101,5 +137,21 @@ export class LocalCollection<TMetadata = unknown> {
 
   delete(): void {
     this.workspace.rmdirSync(this.uri, { recursive: true });
+  }
+
+  private sortDocumentsByIndex(documents: LocalDocument<TMetadata>[]): LocalDocument<TMetadata>[] {
+    return documents.slice().sort(
+      (a, b) => {
+        if (a.metadata().index === undefined) {
+          throw new Error(`Found document with id '${a.id}' but no index`)
+        }
+
+        if (!b.metadata().index === undefined) {
+          throw new Error(`Found document with id '${b.id}' but no index`)
+        }
+
+        return a.metadata().index - b.metadata().index
+      }
+    );
   }
 }

--- a/packages/agent-utils/src/embeddings/LocalDocumentStore.ts
+++ b/packages/agent-utils/src/embeddings/LocalDocumentStore.ts
@@ -1,9 +1,9 @@
 import { Workspace } from "../sys";
 import path from "path-browserify";
 import { v4 as uuid } from "uuid";
-import { LocalDocument } from "./LocalDocument";
+import { BaseDocumentMetadata, LocalDocument } from "./LocalDocument";
 
-export class LocalDocumentStore<TMetadata = unknown> {
+export class LocalDocumentStore<TMetadata extends BaseDocumentMetadata = BaseDocumentMetadata> {
   constructor(
     private workspace: Workspace,
     private uri: string

--- a/packages/agent-utils/src/embeddings/LocalVectorDB.ts
+++ b/packages/agent-utils/src/embeddings/LocalVectorDB.ts
@@ -11,7 +11,7 @@ export class LocalVectorDB {
     private embeddingApi: EmbeddingApi,
   ) {}
 
-  addCollection<TMetadata>(name: string): LocalCollection<TMetadata> {
+  addCollection<TMetadata extends BaseDocumentMetadata = BaseDocumentMetadata>(name: string): LocalCollection<TMetadata> {
     const collection = new LocalCollection<TMetadata>(
       path.join(this.uri, name),
       this.embeddingApi,

--- a/packages/agent-utils/src/embeddings/LocalVectorDB.ts
+++ b/packages/agent-utils/src/embeddings/LocalVectorDB.ts
@@ -2,6 +2,7 @@ import { Workspace } from "../sys";
 import { LocalCollection } from "./LocalCollection";
 import { EmbeddingApi } from "./EmbeddingApi";
 import path from "path-browserify";
+import { BaseDocumentMetadata } from "./LocalDocument";
 
 export class LocalVectorDB {
   constructor(
@@ -34,7 +35,7 @@ export class LocalVectorDB {
     } catch {}
   }
 
-  listCollections(): LocalCollection[] {
+  listCollections<TMetadata extends BaseDocumentMetadata = BaseDocumentMetadata>(): LocalCollection<TMetadata>[] {
     const names = this.workspace.readdirSync(this.uri).map(entry => entry.name)
     return names.map(name => new LocalCollection(
       path.join(this.uri, name),


### PR DESCRIPTION
This PR contains 3 changes:

- Added search with surroundings (matches a chunk and gets characters around it in the original doc)
- Made metadata indexes always available (if user does not pass their own indexes, they get autogen'd) so they always exist.
- Made limit parameter optional in search (so now you can get all doc references)