### PR TITLE
chore: guarantee chars to tokens is integer

### DIFF
--- a/packages/agents/src/agents/Chameleon/helpers.ts
+++ b/packages/agents/src/agents/Chameleon/helpers.ts
@@ -2,7 +2,7 @@ export const previewChunks = (chunks: string[], charLimit: number): string => jo
 export const limitChunks = (chunks: string[], charLimit: number): string[] => getUnderCharLimit(chunks, charLimit)
 
 export const tokensToChars = (tokenCnt: number) => tokenCnt * 4;
-export const charsToTokens = (charCnt: number) => charCnt / 4;
+export const charsToTokens = (charCnt: number) => Math.floor(charCnt / 4);
 
 const joinUnderCharLimit = (chunks: string[], characterLimit: number, separator: string): string => {
   let result = "";


### PR DESCRIPTION
this avoids having decimals in as the max tokens and having this error
```
Error: {
  "status": 400,
  "data": {
    "error": {
      "message": "139.75 is not of type 'integer' - 'max_tokens'",
      "type": "invalid_request_error",
      "param": null,
      "code": null
    }
  },
  "message": "Request failed with status code 400"
}
```