### PR TITLE
chore: icons are not huge on load

### DIFF
--- a/apps/browser/pages/_app.tsx
+++ b/apps/browser/pages/_app.tsx
@@ -5,6 +5,9 @@ import { Exo } from "next/font/google";
 import "../styles/globals.css";
 import clsx from "clsx";
 import Script from "next/script";
+import { config } from '@fortawesome/fontawesome-svg-core'
+import '@fortawesome/fontawesome-svg-core/styles.css'
+config.autoAddCss = false
 
 export const EXO_FONT = Exo({
   subsets: ["latin"],


### PR DESCRIPTION
right now when evo.ninja loads, the icons are huge - this change makes it looks with the correct size; in the following video i demonstrate the difference of behavior:

[Screencast from 10-11-23 16:06:38.webm](https://github.com/polywrap/evo.ninja/assets/21031138/8c86ae53-84f5-47ec-a6ab-ad42d9c7b605)

