### PR TITLE
OnMessagesAdded hook for Evo's Chat

### DIFF
--- a/packages/agents/src/__tests__/llm.spec.ts
+++ b/packages/agents/src/__tests__/llm.spec.ts
@@ -66,13 +66,8 @@ describe('LLM Test Suite', () => {
     );
     const chat = new Chat(cl100k_base);
 
-    for (const msg of msgs.persistent.msgs) {
-      chat.persistent(msg.role as ChatRole, msg.content ?? "");
-    }
-
-    for (const msg of msgs.temporary.msgs) {
-      chat.temporary(msg.role as ChatRole, msg.content ?? "");
-    }
+    await chat.persistent(msgs.persistent.msgs);
+    await chat.temporary(msgs.temporary.msgs);
 
     for (let i = 0; i < 20; i++) {
       const response = await llm.getResponse(

--- a/packages/agents/src/agent-core/agent/basicFunctionCallLoop.ts
+++ b/packages/agents/src/agent-core/agent/basicFunctionCallLoop.ts
@@ -37,8 +37,10 @@ export async function* basicFunctionCallLoop(
       const { name, arguments: fnArgs } = response.function_call
       const sanitizedFunctionAndArgs = processFunctionAndArgs(name, fnArgs, allFunctions, context.variables)
       if (!sanitizedFunctionAndArgs.ok) {
-        chat.temporary(response);
-        chat.temporary("system", sanitizedFunctionAndArgs.error);
+        await chat.temporary([
+          response,
+          { role: "system", content: sanitizedFunctionAndArgs.error ?? null }
+        ])
         yield { type: AgentOutputType.Error, title: `Failed to sanitize function ${name} with args ${fnArgs}. Error: ${sanitizedFunctionAndArgs.error}`, content: sanitizedFunctionAndArgs.error } as AgentOutput;
         continue;
       }
@@ -57,7 +59,8 @@ export async function* basicFunctionCallLoop(
         }
       }
 
-      result.messages.forEach(x => chat.temporary(x));
+      await chat.temporary(result.messages);
+
       const terminate = functionCalled && shouldTerminate(functionCalled, result);
       for (let i = 0; i < result.outputs.length; i++) {
         const output = result.outputs[i];
@@ -77,15 +80,17 @@ export async function* basicFunctionCallLoop(
 async function* _preventLoopAndSaveMsg(chat: Chat, response: ChatMessage, loopPreventionPrompt: string, agentSpeakPrompt: string): AsyncGenerator<AgentOutput, void, string | undefined> {
   if (chat.messages[chat.messages.length - 1].content === response.content &&
     chat.messages[chat.messages.length - 2].content === response.content) {
-      chat.temporary("system", loopPreventionPrompt);
+      await chat.temporary("system", loopPreventionPrompt);
       yield {
         type: AgentOutputType.Warning,
         title: "Loop prevention",
         content: loopPreventionPrompt
       } as AgentOutput;
   } else {
-    chat.temporary(response);
-    chat.temporary("system", agentSpeakPrompt);
+    await chat.temporary([
+      response,
+      { role: "system", content: agentSpeakPrompt }
+    ])
     yield {
       type: AgentOutputType.Message,
       title: "Agent message",

--- a/packages/agents/src/agent-core/llm/chat/Chat.ts
+++ b/packages/agents/src/agent-core/llm/chat/Chat.ts
@@ -7,7 +7,12 @@ export type ChatRole = ChatCompletionRole;
 export class Chat {
   protected _chatLogs: ChatLogs;
 
-  constructor(protected _tokenizer: Tokenizer) {
+  constructor(
+    protected _tokenizer: Tokenizer,
+    protected options?: {
+      onMessagesAdded?: (msgs: ChatMessage[]) => Promise<void>
+    }
+  ) {
     this._chatLogs = new ChatLogs();
   }
 
@@ -27,56 +32,71 @@ export class Chat {
     return this._chatLogs.messages;
   }
 
-  public add(type: ChatLogType, msg: ChatMessage | ChatMessage[]) {
+  public async add(type: ChatLogType, msg: ChatMessage | ChatMessage[]): Promise<void> {
     let msgs = Array.isArray(msg) ? msg : [msg];
 
-    for (const msg of msgs) {
+    const msgsWithTokens = msgs.map((msg) => {
       const tokens = this._tokenizer.encode(JSON.stringify(msg)).length;
-      this._chatLogs.add(type, [msg], [tokens]);
+      return { ...msg, tokens };
+    })
+
+    const msgsToAdd = msgsWithTokens.map(({ tokens, ...msg }) => msg);
+    const tokensToAdd = msgsWithTokens.map(({ tokens }) => tokens);
+
+    this._chatLogs.add(type, msgsToAdd, tokensToAdd)
+
+    if (this.options?.onMessagesAdded) {
+      await this.options.onMessagesAdded(msgsToAdd);
     }
   }
 
-  public persistent(role: ChatRole, content: string): string | undefined;
-  public persistent(
+  public async persistent(role: ChatRole, content: string): Promise<void>;
+  public async persistent(
     msg: ChatMessage
-  ): string | undefined;
-  public persistent(
-    roleOrMsg: ChatRole | ChatMessage,
+  ): Promise<void>;
+  public async persistent(
+    msgs: ChatMessage[]
+  ): Promise<void>;
+  public async persistent(
+    roleOrMsg: ChatRole | ChatMessage | ChatMessage[],
     content?: string
-  ): string | undefined {
+  ): Promise<void> {
     switch (typeof roleOrMsg) {
       case "string":
-        this.add("persistent", {
+        await this.add("persistent", {
           role: roleOrMsg as "system" | "user" | "assistant",
           content: content ?? null,
         });
-        return content;
+        break;
       case "object":
-        this.add("persistent", roleOrMsg as ChatMessage);
-        return roleOrMsg.content || undefined;
+        await this.add("persistent", roleOrMsg);
+        break;
       default:
         throw new Error(`Invalid type for roleOrMsg: ${typeof roleOrMsg}`);
     }
   }
 
-  public temporary(
+  public async temporary(
     role: ChatRole,
     content?: string
-  ): string | undefined;
-  public temporary(
+  ): Promise<void>;
+  public async temporary(
     msg: ChatMessage
-  ): string | undefined;
-  public temporary(
-    roleOrMsg: ChatRole | ChatMessage,
+  ): Promise<void>;
+  public async temporary(
+    msgs: ChatMessage[]
+  ): Promise<void>;
+  public async temporary(
+    roleOrMsg: ChatRole | ChatMessage | ChatMessage[],
     content?: string
-  ): string | undefined {
+  ): Promise<void> {
     switch(typeof roleOrMsg) {
       case "string":
-        this.add("temporary", { role: roleOrMsg as "system" | "user", content: content ?? null });
-        return content;
+        await this.add("temporary", { role: roleOrMsg as "system" | "user", content: content ?? null });
+        break;
       case "object":
-        this.add("temporary", roleOrMsg as ChatMessage);
-        return roleOrMsg.content || undefined;
+        await this.add("temporary", roleOrMsg as ChatMessage);
+        break;
       default:
         throw new Error(`Invalid type for roleOrMsg: ${typeof roleOrMsg}`);
     }

--- a/packages/agents/src/agent-core/llm/chat/Chat.ts
+++ b/packages/agents/src/agent-core/llm/chat/Chat.ts
@@ -33,20 +33,18 @@ export class Chat {
   }
 
   public async add(type: ChatLogType, msg: ChatMessage | ChatMessage[]): Promise<void> {
-    let msgs = Array.isArray(msg) ? msg : [msg];
+    const msgs = Array.isArray(msg) ? msg : [msg];
 
     const msgsWithTokens = msgs.map((msg) => {
       const tokens = this._tokenizer.encode(JSON.stringify(msg)).length;
       return { ...msg, tokens };
     })
+    const tokens = msgsWithTokens.map(({ tokens }) => tokens);
 
-    const msgsToAdd = msgsWithTokens.map(({ tokens, ...msg }) => msg);
-    const tokensToAdd = msgsWithTokens.map(({ tokens }) => tokens);
-
-    this._chatLogs.add(type, msgsToAdd, tokensToAdd)
+    this._chatLogs.add(type, msgs, tokens)
 
     if (this.options?.onMessagesAdded) {
-      await this.options.onMessagesAdded(msgsToAdd);
+      await this.options.onMessagesAdded(msgs);
     }
   }
 

--- a/packages/agents/src/agent-core/llm/chat/ContextualizedChat.ts
+++ b/packages/agents/src/agent-core/llm/chat/ContextualizedChat.ts
@@ -101,8 +101,8 @@ export class ContextualizedChat {
     sorted.temporary = postProcessMessages(sorted.temporary);
 
     const chat = this._rawChat.cloneEmpty();
-    chat.add("persistent", sorted.persistent);
-    chat.add("temporary", sorted.temporary);
+    await chat.persistent(sorted.persistent);
+    await chat.temporary(sorted.temporary);
     return chat;
   }
 

--- a/packages/agents/src/agents/Evo/index.ts
+++ b/packages/agents/src/agents/Evo/index.ts
@@ -64,13 +64,17 @@ export class Evo extends Agent<GoalRunArgs> {
     );
   }
 
-  protected initializeChat(args: GoalRunArgs): void {
+  protected async initializeChat(args: GoalRunArgs): Promise<void> {
     const { chat } = this.context;
 
-    chat.persistent(buildDirectoryPreviewMsg(this.context.workspace));
-    chat.persistent("user", prompts.exhaustAllApproaches);
-    chat.persistent("user", prompts.variablesExplainer);
-    chat.persistent("user", args.goal);
+    const initialMessages: ChatMessage[] = [
+      buildDirectoryPreviewMsg(this.context.workspace),
+      { role: "user", content: prompts.exhaustAllApproaches },
+      { role: "user", content: prompts.variablesExplainer },
+      { role: "user", content: args.goal },
+    ]
+
+    await chat.persistent(initialMessages);
     this.goal = args.goal;
   }
 

--- a/packages/agents/src/agents/utils/Agent.ts
+++ b/packages/agents/src/agents/utils/Agent.ts
@@ -39,7 +39,7 @@ export class Agent<TRunArgs = GoalRunArgs> implements RunnableAgent<TRunArgs> {
   public async* run(
     args: TRunArgs
   ): AsyncGenerator<AgentOutput, RunResult, string | undefined> {
-    this.initializeChat(args);
+    await this.initializeChat(args);
 
     const { chat } = this.context;
 
@@ -94,7 +94,7 @@ export class Agent<TRunArgs = GoalRunArgs> implements RunnableAgent<TRunArgs> {
       }
     }
 
-    result.messages.forEach(x => chat.temporary(x));
+    await chat.temporary(result.messages);
   }
 
   protected query(msgs?: ChatMessage[]): LlmQuery {
@@ -113,12 +113,11 @@ export class Agent<TRunArgs = GoalRunArgs> implements RunnableAgent<TRunArgs> {
     return (await this.context.embedding.createEmbeddings(text))[0].embedding;
   }
 
-  protected initializeChat(args: TRunArgs) {
-    this.context.chat.persistent("system", `Variables are annotated using the \${variable-name} syntax. Variables can be used as function argument using the \${variable-name} syntax. Variables are created as needed, and do not exist unless otherwise stated.`);
-    
-    for (const message of this.config.prompts.initialMessages(args)) {
-      this.context.chat.persistent(message.role, message.content ?? "");
-    }
+  protected async initializeChat(args: TRunArgs) {
+    await this.context.chat.persistent([
+      { role: "system", content: `Variables are annotated using the \${variable-name} syntax. Variables can be used as function argument using the \${variable-name} syntax. Variables are created as needed, and do not exist unless otherwise stated.` },
+      ...this.config.prompts.initialMessages(args)
+    ]);
   }
 
   protected async beforeLlmResponse(): Promise<{ logs: ChatLogs, agentFunctions: FunctionDefinition[], allFunctions: AgentFunction<AgentContext>[]}> {


### PR DESCRIPTION
In order to persist chat, among other potential uses, I added a onMessagesAdded option to Chat. This way we could, for example, add a new message to the DB chat whenever the hook runs.

I also re-checked Evo's internal workings and indeed there's no modification or manipulation of the original chat instance; nor is it replaced by another instance either (as I initially thought).

Additionally I added an overload for both `temporary` and `persistent` methods to accept arrays of messages. This way, in practice, the hook runs on batches of messages when possible. I updated the usages of these methods for this purpose