### PR TITLE
Added import statement for nodes path module for windows compatibility.

### DIFF
--- a/packages/agent-utils-fs/src/FileSystemWorkspace.ts
+++ b/packages/agent-utils-fs/src/FileSystemWorkspace.ts
@@ -4,13 +4,16 @@ import {
   SyncWorkspace,
 } from "@evo-ninja/agent-utils";
 import fs from "fs";
-import path from "path-browserify";
+import pathBrowserify from "path-browserify";
+import path from "path";
 import spawn from "spawn-command";
 
+// Path module will use node's path module on windows and browserify's path module on other platforms to ensure compatibility
+const pathModule = process.platform !== "win32" ? pathBrowserify : path;
 export class FileSystemWorkspace implements Workspace, SyncWorkspace {
   constructor(private _workspacePath: string) {
     // Fully resolve the workspace path
-    this._workspacePath = path.resolve(this._workspacePath);
+    this._workspacePath = pathModule.resolve(_workspacePath);
 
     // Initialize the directory
     if (!fs.existsSync(this._workspacePath)) {
@@ -19,9 +22,9 @@ export class FileSystemWorkspace implements Workspace, SyncWorkspace {
   }
 
   toWorkspacePath(subpath: string): string {
-    const absPath = path.resolve(
+    const absPath = pathModule.resolve(
       !subpath.startsWith(this._workspacePath)
-        ? path.join(this._workspacePath, subpath)
+        ? pathModule.join(this._workspacePath, subpath)
         : subpath
     );
 


### PR DESCRIPTION
---

### Issue Description

**Problem:**
- The CLI application was unable to run on Windows systems due to reliance on `path-browserify`, which supports only POSIX path conventions, lacking Win32 command support. The issue stemmed from a hardcoded forward slash (`/`) used for creating absolute paths, without checking the operating system.

### Solution

**Implementation Details:**
- The `path` module was imported from Node.js.
- A new variable, `pathModule`, was introduced to perform an OS check.
  - For Win32 systems, it defaults to Node.js's `path` implementation.
  - For other systems, it defaults to `path-browserify` to maintain existing compatibility.

### Testing Performed

**Completed Tests:**
- Ran `yarn & yarn build` to ensure build integrity.
- Executed `yarn start` for testing in a Node.js environment.
- Ran `yarn start:browser` for browser compatibility testing.

**Further Testing Required:**
- Verification on a Linux system is needed to ensure no compatibility issues or regressions, as testing on Linux was not feasible during development as I do not have a box ready.

---
