### PR TITLE
Added ReadDirectoryFunction to the relevant agents allowing them to r…

### DIFF
--- a/packages/agents/src/agents/Developer/index.ts
+++ b/packages/agents/src/agents/Developer/index.ts
@@ -4,6 +4,7 @@ import { InitPoetryFunction } from "../../functions/InitPoetry";
 import { prompts } from "./prompts";
 import { RunPytest } from "../../functions/RunPytest";
 import { WriteFileFunction } from "../../functions/WriteFile";
+import { ReadDirectoryFunction } from "../../functions";
 import { Agent, AgentConfig } from "../utils";
 
 export class DeveloperAgent extends Agent {
@@ -14,6 +15,7 @@ export class DeveloperAgent extends Agent {
         [
           new WriteFileFunction(context.scripts),
           new ReadFileFunction(context.scripts),
+          new ReadDirectoryFunction(context.scripts),
           new RunPytest(),
           new InitPoetryFunction(),
         ],
@@ -24,7 +26,7 @@ export class DeveloperAgent extends Agent {
   }
 }
 
-/*public override async onFirstRun(args: GoalRunArgs, chat: Chat): Promise<void> {
+/* public override async onFirstRun(args: GoalRunArgs, chat: Chat): Promise<void> {
   await Promise.all([
     this.executeFunction(new InitPoetryFunction(), {}, chat),
     this.executeFunction(new PlanDevelopmentFunction(), args, chat)

--- a/packages/agents/src/agents/Researcher/index.ts
+++ b/packages/agents/src/agents/Researcher/index.ts
@@ -5,6 +5,7 @@ import { prompts } from "./prompts";
 import { ReadFileFunction } from "../../functions/ReadFile";
 import { WriteFileFunction } from "../../functions/WriteFile";
 import { ScrapeTextFunction } from "../../functions/ScrapeText";
+import { ReadDirectoryFunction } from "../../functions/ReadDirectory";
 import { Agent, AgentConfig, GoalRunArgs } from "../utils";
 
 export class ResearcherAgent extends Agent {
@@ -19,6 +20,7 @@ export class ResearcherAgent extends Agent {
           new ScrapeTextFunction(),
           new ReadFileFunction(context.scripts),
           new WriteFileFunction(context.scripts),
+          new ReadDirectoryFunction(context.scripts),
         ],
         context.scripts
       ),

--- a/packages/agents/src/agents/Scripter/Scripter.ts
+++ b/packages/agents/src/agents/Scripter/Scripter.ts
@@ -20,8 +20,8 @@ export class ScripterAgent extends Agent {
           new ReadFileFunction(context.scripts),
           new WriteFileFunction(context.scripts),
           new ReadDirectoryFunction(context.scripts),
-        ], 
-        context.scripts,
+        ],
+        context.scripts
       ),
       context
     );

--- a/packages/agents/src/agents/Synthesizer/index.ts
+++ b/packages/agents/src/agents/Synthesizer/index.ts
@@ -1,18 +1,19 @@
 import { WriteFileFunction } from "../../functions/WriteFile";
 import { ReadFileFunction } from "../../functions/ReadFile";
+import { ReadDirectoryFunction } from "../../functions/ReadDirectory";
 import { AgentContext } from "@/agent-core";
 import { prompts } from "./prompts";
 import { Agent, AgentConfig } from "../utils";
 
 export class SynthesizerAgent extends Agent {
   constructor(context: AgentContext) {
-
     super(
       new AgentConfig(
         () => prompts,
         [
           new WriteFileFunction(context.scripts),
           new ReadFileFunction(context.scripts),
+          new ReadDirectoryFunction(context.scripts),
         ],
         context.scripts
       ),


### PR DESCRIPTION
---

### Pull Request - Add ReadDirectoryFunction to Relevant Agents

#### Description of Changes

**Overview:**
- Implemented `ReadDirectoryFunction` in the relevant agents.
- This enhancement allows these agents to read and understand directories within their workspace.
- Minor ESLint recommended formatting changes
- Addresses issue [577](https://github.com/polywrap/evo.ninja/issues/577)

**Problem Addressed:**
- Previously, the relevant agents lacked access to the read directory function. This limitation hindered their ability to effectively manage and interact with directories in their workspace.

#### Implementation Details

- Added `ReadDirectoryFunction` to agents where it was necessary.
- Ensured that this addition is compatible with the existing functionalities of the agents.

#### Testing Performed

**Completed Tests:**
- Ran `yarn & yarn build` to verify build integrity.
- Executed `yarn start` to test the application in a Node.js environment.
- Ran `yarn start:browser` to confirm browser compatibility.
- Ran agent with task requiring folder exploration, logs below

**Logs:**
- New logs demonstrating the functionality: [here](https://pastebin.com/kxBf4Zyr)
- Old logs for comparison: [here](https://pastebin.com/Czq9fjPr)

**Further Testing Required:**
N/A

---