### PR TITLE
feat: use per-chat-goal evo instances

### DIFF
--- a/apps/browser/app/page.tsx
+++ b/apps/browser/app/page.tsx
@@ -101,7 +101,7 @@ function Dojo({ params }: { params: { id?: string } }) {
 
     const authorized = await handlePromptAuth(newMessage, chatIdRef.current);
 
-    if (!authorized) {
+    if (!authorized.complete) {
       return;
     }
 
@@ -111,7 +111,7 @@ function Dojo({ params }: { params: { id?: string } }) {
     });
 
     setIsSending(true);
-    start(newMessage);
+    start(newMessage, authorized.goalId as string);
   };
 
   const {

--- a/apps/browser/app/page.tsx
+++ b/apps/browser/app/page.tsx
@@ -10,37 +10,30 @@ import { useAddChatLog } from "@/lib/mutations/useAddChatLog";
 import { useAddMessages } from "@/lib/mutations/useAddMessages";
 import { useAddVariable } from "@/lib/mutations/useAddVariable";
 import { useCreateChat } from "@/lib/mutations/useCreateChat";
-import { useChats } from "@/lib/queries/useChats";
+import { useChat } from "@/lib/hooks/useChat";
 import { ChatLogType, ChatMessage } from "@evo-ninja/agents";
 import { useSession } from "next-auth/react";
 import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { useAtom } from "jotai";
-import { errorAtom } from "@/lib/store";
 
 function Dojo({ params }: { params: { id?: string } }) {
   const { mutateAsync: createChat } = useCreateChat()
   const { mutateAsync: addMessages } = useAddMessages()
   const { mutateAsync: addChatLog } = useAddChatLog()
   const { mutateAsync: addVariable } = useAddVariable()
-  
+
   const { handlePromptAuth } = useHandleAuth();
   const checkForUserFiles = useCheckForUserFiles();
   const router = useRouter()
-  const [, setError] = useAtom(errorAtom)
 
   const { status: sessionStatus } = useSession()
-  const { data: chats } = useChats()
 
   const chatIdRef = useRef<string | undefined>(params.id)
   const isAuthenticatedRef = useRef<boolean>(false);
   const inMemoryLogsRef = useRef<ChatLog[]>([])
-
   const [inMemoryLogs, setInMemoryLogs] = useState<ChatLog[]>([])
 
-  const currentChat = chats?.find(c => c.id === chatIdRef.current)
-  const logs = currentChat?.logs ?? []
-  const logsToShow = isAuthenticatedRef.current ? logs : inMemoryLogs;
+  const logs = useChat(chatIdRef.current);
 
   const onMessagesAdded = async (type: ChatLogType, messages: ChatMessage[]) => {
     if (!isAuthenticatedRef.current) {
@@ -93,7 +86,7 @@ function Dojo({ params }: { params: { id?: string } }) {
   const handleSend = async (newMessage: string) => {
     if (!newMessage) return;
 
-    if (!currentChat?.messages.length && isAuthenticatedRef.current && !params.id) {
+    if (!logs.length && isAuthenticatedRef.current && !params.id) {
       const chatId = uuid();
       const createdChat = await createChat(chatId)
 
@@ -147,19 +140,12 @@ function Dojo({ params }: { params: { id?: string } }) {
       router.push('/')
       return;
     }
-
-    if (sessionStatus === "authenticated" && params.id && chats && !currentChat) {
-      setError(`Chat with id '${params.id}' not found`)
-      router.push('/')
-      return;
-    }
-
-  }, [sessionStatus, currentChat, params.id])
+  }, [sessionStatus, params.id])
 
   return (
     <Chat
-      logs={logsToShow}
-      samplePrompts={!logsToShow.length ? examplePrompts: undefined}
+      logs={logs.length ? logs : inMemoryLogs}
+      samplePrompts={examplePrompts}
       isPaused={isPaused}
       isRunning={isRunning}
       isSending={isSending}

--- a/apps/browser/components/Chat.tsx
+++ b/apps/browser/components/Chat.tsx
@@ -20,7 +20,7 @@ export interface ChatLog {
 
 export interface ChatProps {
   logs: ChatLog[];
-  samplePrompts?: ExamplePrompt[];
+  samplePrompts: ExamplePrompt[];
   isRunning: boolean;
   isStopped: boolean;
   isPaused: boolean;
@@ -138,7 +138,7 @@ const Chat: React.FC<ChatProps> = ({
           </div>
         ))}
       </div>
-      {samplePrompts?.length ? (
+      {!message.length && !logs.length ? (
         <div className="grid w-full grid-rows-2 p-2.5 py-16 self-center w-[100%] max-w-[56rem]">
           {samplePrompts.map((prompt, index) => (
             <div 

--- a/apps/browser/lib/hooks/useChat.ts
+++ b/apps/browser/lib/hooks/useChat.ts
@@ -1,0 +1,24 @@
+import { useChats } from "@/lib/queries/useChats";
+import { errorAtom } from "@/lib/store";
+import { useAtom } from "jotai";
+import { useRouter } from "next/navigation";
+
+export const useChat = (chatId: string | undefined) => {
+  const { data: chats } = useChats();
+  const router = useRouter();
+  const [, setError] = useAtom(errorAtom);
+
+  if (!chats) {
+    return [];
+  }
+
+  const currentChat = chats.find(c => c.id === chatId);
+
+  if (chatId && !currentChat) {
+    setError(`Chat with id '${chatId}' not found`);
+    router.push('/');
+  }
+
+  const logs = currentChat?.logs ?? [];
+  return logs;
+}

--- a/apps/browser/lib/hooks/useEvo.ts
+++ b/apps/browser/lib/hooks/useEvo.ts
@@ -26,8 +26,6 @@ import { useAtom } from "jotai";
 import { ChatLog } from "@/components/Chat";
 import {
   capReachedAtom,
-  proxyEmbeddingAtom,
-  proxyLlmAtom,
   localOpenAiApiKeyAtom,
   userWorkspaceAtom,
 } from "@/lib/store";

--- a/apps/browser/lib/hooks/useEvo.ts
+++ b/apps/browser/lib/hooks/useEvo.ts
@@ -61,6 +61,7 @@ export function useEvo({
 
   const [error, setError] = useState<string | undefined>();
   const [localOpenAiApiKey] = useAtom(localOpenAiApiKeyAtom);
+  const [evo, setEvo] = useState<Evo | undefined>();
 
   const [, setCapReached] = useAtom(capReachedAtom);
   const [userWorkspace, setUserWorkspace] = useAtom(userWorkspaceAtom);
@@ -153,6 +154,7 @@ export function useEvo({
           agentVariables
         )
       );
+      setEvo(evo);
       return evo;
     } catch (e: any) {
       setError(e.message);
@@ -201,6 +203,7 @@ export function useEvo({
           setIsRunning(false);
           setIterator(undefined);
           setIsSending(false);
+          evo?.reset();
           break;
         }
 

--- a/apps/browser/lib/hooks/useHandleAuth.ts
+++ b/apps/browser/lib/hooks/useHandleAuth.ts
@@ -4,8 +4,6 @@ import {
   allowTelemetryAtom,
   capReachedAtom,
   localOpenAiApiKeyAtom,
-  proxyEmbeddingAtom,
-  proxyLlmAtom,
   showAccountModalAtom,
 } from "../store";
 import { useSession } from "next-auth/react";
@@ -18,21 +16,25 @@ export function useHandleAuth() {
   const [allowTelemetry] = useAtom(allowTelemetryAtom);
   const [localOpenAiApiKey] = useAtom(localOpenAiApiKeyAtom);
   const [, setCapReached] = useAtom(capReachedAtom);
-  const [proxyLlmApi] = useAtom(proxyLlmAtom);
-  const [proxyEmbeddingApi] = useAtom(proxyEmbeddingAtom);
 
   const { data: session } = useSession();
 
   const firstTimeUser = !localOpenAiApiKey && !session?.user;
 
-  const handlePromptAuth = async (message: string, chatId: string | undefined) => {
+  const handlePromptAuth = async (
+    message: string,
+    chatId: string | undefined
+  ): Promise<{
+    complete: boolean;
+    goalId?: string;
+  }> => {
     if (awaitingAuth) {
-      return false;
+      return { complete: false };
     }
 
     if (firstTimeUser) {
       setAccountModalOpen(true);
-      return false;
+      return { complete: false };
     }
 
     const subsidize = !localOpenAiApiKey;
@@ -50,12 +52,13 @@ export function useHandleAuth() {
     setAwaitingAuth(false);
 
     if (!goalId) {
-      return false;
+      return { complete: false };
     }
 
-    proxyLlmApi?.setGoalId(goalId);
-    proxyEmbeddingApi?.setGoalId(goalId);
-    return true;
+    return {
+      complete: true,
+      goalId: goalId
+    };
   };
   return {
     handlePromptAuth,

--- a/apps/browser/lib/store.ts
+++ b/apps/browser/lib/store.ts
@@ -2,7 +2,6 @@ import { Workspace } from "@evo-ninja/agent-utils";
 import { InMemoryFile } from "@nerfzael/memory-fs";
 import { atom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
-import { ProxyEmbeddingApi, ProxyLlmApi } from "./api";
 
 export const localOpenAiApiKeyAtom = atomWithStorage<string | null>(
   "openai-api-key",
@@ -19,5 +18,3 @@ export const uploadedFilesAtom = atom<InMemoryFile[]>([]);
 export const userWorkspaceAtom = atom<Workspace | undefined>(undefined);
 export const sidebarAtom = atom<boolean>(true)
 export const chatIdAtom = atom<string>("")
-export const proxyLlmAtom = atom<ProxyLlmApi | undefined>(undefined)
-export const proxyEmbeddingAtom = atom<ProxyEmbeddingApi | undefined>(undefined)

--- a/apps/browser/lib/store.ts
+++ b/apps/browser/lib/store.ts
@@ -3,8 +3,6 @@ import { InMemoryFile } from "@nerfzael/memory-fs";
 import { atom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import { ProxyEmbeddingApi, ProxyLlmApi } from "./api";
-import { SupabaseClient, createClient } from "@supabase/supabase-js";
-import { Database } from "./supabase/dbTypes";
 
 export const localOpenAiApiKeyAtom = atomWithStorage<string | null>(
   "openai-api-key",

--- a/apps/browser/scripts/build.scripts.js
+++ b/apps/browser/scripts/build.scripts.js
@@ -32,9 +32,9 @@ const scripts = uniqueFilesWithoutExtension.map((name) => {
   };
 });
 
-const templateFile = `import { InMemoryWorkspace, Workspace } from "@evo-ninja/agent-utils";
+const templateFile = `import { InMemoryWorkspace } from "@evo-ninja/agent-utils";
 
-export async function createInBrowserScripts(): Promise<InMemoryWorkspace> {
+export function createInBrowserScripts(): InMemoryWorkspace {
   const workspace = new InMemoryWorkspace();
 
   const availableScripts = [
@@ -43,20 +43,17 @@ export async function createInBrowserScripts(): Promise<InMemoryWorkspace> {
     {{/each}}
   ];
 
-  await Promise.all(
-    availableScripts.map((script) => addScript(script, workspace))
-  );
+  availableScripts.forEach((script) => addScript(script, workspace));
 
   return workspace;
 }
 
-
-async function addScript(
+function addScript(
   script: { name: string; definition: string; code: string },
-  scriptsWorkspace: Workspace
-): Promise<void> {
-  await scriptsWorkspace.writeFile(script.name.concat(".json"), script.definition);
-  await scriptsWorkspace.writeFile(script.name.concat(".js"), script.code);
+  scriptsWorkspace: InMemoryWorkspace
+): void {
+  scriptsWorkspace.writeFileSync(script.name.concat(".json"), script.definition);
+  scriptsWorkspace.writeFileSync(script.name.concat(".js"), script.code);
 }
 
 // Scripts embedded below


### PR DESCRIPTION
closes #569 

Explanation of approach taken here: https://github.com/polywrap/evo.ninja/issues/569#issuecomment-1853045302

Scenarios Tested:
* Create new evo instance every time goal is submitted.
* Ensure existing evo instance is not interrupted when OpenAI key changes.
* Persist evo's running goal in unselected chats in the background.
* Logged in and anonymous users.
* Invalid `/chat/...` URLs