### PR TITLE
Remember previous goal context

### DIFF
--- a/apps/browser/lib/hooks/useEvo.ts
+++ b/apps/browser/lib/hooks/useEvo.ts
@@ -161,9 +161,10 @@ export function useEvo({
     }
   };
 
-  const start = (goal: string, goalId: string) => {
+  const start = async (goal: string, goalId: string) => {
     const evo = createEvoInstance(goalId);
     if (!evo) return;
+    await evo.init();
     setIterator(evo.run({ goal }));
     setIsRunning(true);
   };

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -33,7 +33,7 @@ export async function cli(): Promise<void> {
   async function handleGoal(goal: string): Promise<void> {
     await app.debugLog?.goalStart(goal);
 
-    let iterator = app.evo.run({ goal });
+    let iterator = app.evo.runWithExistingContext({ goal });
     let stepCounter = 1;
 
     while (true) {
@@ -74,6 +74,7 @@ export async function cli(): Promise<void> {
   let goal: string | undefined = program.args[0];
   let goalCounter = 0;
 
+  await app.evo.init();
   while (true) {
     if (!goal) {
       goal = await app.logger.prompt("Enter your goal");

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -33,7 +33,7 @@ export async function cli(): Promise<void> {
   async function handleGoal(goal: string): Promise<void> {
     await app.debugLog?.goalStart(goal);
 
-    let iterator = app.evo.runWithExistingContext({ goal });
+    let iterator = app.evo.run({ goal });
     let stepCounter = 1;
 
     while (true) {

--- a/packages/agents/src/agents/CsvAnalyst/prompts.ts
+++ b/packages/agents/src/agents/CsvAnalyst/prompts.ts
@@ -4,7 +4,7 @@ import { AgentPrompts, GoalRunArgs } from "../utils";
 export const prompts: AgentPrompts<GoalRunArgs> = {
   name: "CsvAnalyst",
   expertise: `adept at reading CSV files, searching for data, extracting key data points, calculating amounts, and derive insights from CSV files.`,
-  initialMessages: ({ goal }: GoalRunArgs): ChatMessage[] => [
+  initialMessages: (): ChatMessage[] => [
     {
       role: "user",
       content:
@@ -15,7 +15,12 @@ PROCESS:
 2. Join Common Column Names - You **ALWAYS** join datasets when column names are the same.
 3. Modify - Modify the data based on the requirements AND analysis you've done prior. Do not modify files you have not read first.`
     },
-    { role: "user", content: goal },
+  ],
+  runMessages: ({ goal }: GoalRunArgs): ChatMessage[] => [
+    {
+      role: "user",
+      content: goal,
+    },
   ],
   loopPreventionPrompt: `Assistant, you appear to be in a loop, try executing a different function.`,
   agentSpeakPrompt: `You do not communicate with the user. If you have insufficient information, it may exist somewhere in the user's filesystem.

--- a/packages/agents/src/agents/Developer/prompts.ts
+++ b/packages/agents/src/agents/Developer/prompts.ts
@@ -4,7 +4,7 @@ import { AgentPrompts, GoalRunArgs } from "../utils";
 export const prompts = (): AgentPrompts<GoalRunArgs> => ({
   name: "Developer",
   expertise: `architect and build complex software. specialized in python`,
-  initialMessages: ({ goal }: GoalRunArgs): ChatMessage[] => [
+  initialMessages: (): ChatMessage[] => [
     {
       role: "user",
       content: `You are an expert developer assistant that excels at coding related tasks.
@@ -23,7 +23,12 @@ you still make unit tests without adding complex logic
 You will always make sure that the implementation and tests are created before running tests with function runPytest
 You must not interact with the user or ask question for clarification. Solve the task to the best of your abilities.`,
     },
-    { role: "user", content: goal },
+  ],
+  runMessages: ({ goal }: GoalRunArgs): ChatMessage[] => [
+    {
+      role: "user",
+      content: goal,
+    },
   ],
   loopPreventionPrompt: `Assistant, you appear to be in a loop, try executing a different function.`,
 });

--- a/packages/agents/src/agents/Evo/findBestAgent.ts
+++ b/packages/agents/src/agents/Evo/findBestAgent.ts
@@ -3,7 +3,6 @@ import { AgentContext } from "@/agent-core";
 import { AgentFunctionBase } from "../../functions/utils";
 import { Agent, GoalRunArgs } from "../utils/Agent";
 import { CsvAnalystAgent } from "../CsvAnalyst";
-import { DeveloperAgent } from "../Developer";
 import { ResearcherAgent } from "../Researcher";
 import { SynthesizerAgent } from "../Synthesizer";
 import { InMemoryWorkspace } from "@evo-ninja/agent-utils";
@@ -36,7 +35,7 @@ export const findBestAgent = async (
   const agentsWithPrompts = allAgents.map(agent => {
     return {
       expertise: agent.config.prompts.expertise + "\n" + agent.config.functions.map(x => x.name).join("\n"),
-      persona: agent.config.prompts.initialMessages({ goal: "" })[0].content ?? "",
+      persona: agent.config.prompts.initialMessages()[0].content ?? "",
       agent,
     };
   });

--- a/packages/agents/src/agents/Evo/prompts.ts
+++ b/packages/agents/src/agents/Evo/prompts.ts
@@ -8,7 +8,8 @@ import { prompts as synthesizerPrompts } from "../Synthesizer/prompts";
 export const agentPrompts = (): AgentPrompts<GoalRunArgs> => ({
   name: "Evo",
   expertise: `an expert evolving assistant that achieves user goals`,
-  initialMessages: ({ goal }: GoalRunArgs): ChatMessage[] => [],
+  initialMessages: (): ChatMessage[] => [],
+  runMessages: ({ goal }: GoalRunArgs): ChatMessage[] => [],
   loopPreventionPrompt: `Assistant, you seem to be looping. Try delegating a task or calling agent_onGoalAchieved or agent_onGoalFailed`,
 });
 

--- a/packages/agents/src/agents/GoalVerifier/prompts.ts
+++ b/packages/agents/src/agents/GoalVerifier/prompts.ts
@@ -9,7 +9,9 @@ export const prompts = (
 ): AgentPrompts<GoalVerifierRunArgs> => ({
   name: "GoalVerifier",
   expertise: `verifies if the users' goal has been achieved or not.`,
-  initialMessages: ({ messagesToVerify }: GoalVerifierRunArgs): ChatMessage[] => [
+  initialMessages: (): ChatMessage[] => [
+  ],
+  runMessages: ({ messagesToVerify }: GoalVerifierRunArgs): ChatMessage[] => [
     { role: "user", content: `\`\`\`
   ${(messagesToVerify ?? []).map(x => JSON.stringify(x, null, 2 )).join("\n")}
 Verify that the assistant has correctly achieved the users' goal by reading the files.

--- a/packages/agents/src/agents/Planner/prompts.ts
+++ b/packages/agents/src/agents/Planner/prompts.ts
@@ -7,7 +7,7 @@ export const prompts = (
 ): AgentPrompts<GoalRunArgs> => ({
   name: "Planner",
   expertise: `I provide a plan that tells you how to achieve any goal`,
-  initialMessages: ({ goal }: GoalRunArgs): ChatMessage[] => [
+  initialMessages: (): ChatMessage[] => [
     {
       role: "user",
       content: `You are an expert planner. 
@@ -26,7 +26,12 @@ export const prompts = (
   You use the ${onGoalAchievedFn.name} function to send plans. You ONLY send the STEP-BY-STEP PLAN text in the message arg of ${onGoalAchievedFn.name}.
   `,
     },
-    { role: "user", content: goal },
+  ],
+  runMessages: ({ goal }: GoalRunArgs): ChatMessage[] => [
+    {
+      role: "user",
+      content: goal,
+    },
   ],
   loopPreventionPrompt: `Assistant, you appear to be in a loop, try executing a different function.`,
 });

--- a/packages/agents/src/agents/Researcher/prompts.ts
+++ b/packages/agents/src/agents/Researcher/prompts.ts
@@ -4,7 +4,7 @@ import { GoalRunArgs } from "../utils";
 export const prompts = {
   name: "Researcher",
   expertise: `Searching the internet, comprehending details, and finding information.`,
-  initialMessages: ({ goal }: GoalRunArgs): ChatMessage[] => [
+  initialMessages: (): ChatMessage[] => [
     {
       role: "user",
       content: `You are an advanced web information retriever. You will receive a goal and need to perform research to answer it.
@@ -25,7 +25,12 @@ export const prompts = {
       
       6. RESPECT USER'S DESIRED FORMAT`,
     },
-    { role: "user", content: goal },
+  ],
+  runMessages: ({ goal }: GoalRunArgs): ChatMessage[] => [
+    {
+      role: "user",
+      content: goal,
+    },
   ],
   loopPreventionPrompt: `Assistant, you appear to be in a loop, try executing a different function.`,
 };

--- a/packages/agents/src/agents/ScriptWriter/prompts.ts
+++ b/packages/agents/src/agents/ScriptWriter/prompts.ts
@@ -6,7 +6,7 @@ import { AgentPrompts } from "../../agents/utils";
 export const prompts: AgentPrompts<ScriptWriterRunArgs> = {
   name: "ScriptWriter",
   expertise: `writing single-purpose scripts`,
-  initialMessages: ({ namespace, description, args }: ScriptWriterRunArgs): ChatMessage[] => [
+  initialMessages: (): ChatMessage[] => [
     {
       role: "user",
       content: `You are an agent designed to write JavaScript functions. 
@@ -15,6 +15,8 @@ export const prompts: AgentPrompts<ScriptWriterRunArgs> = {
 3. Don't get disheartened by initial failures. Retry until success.
 4. Ensure authenticity; avoid creating mock functionality.`,
   },
+  ],
+  runMessages: ({ namespace, description, args }: ScriptWriterRunArgs): ChatMessage[] => [
   {
     role: "user",
     content: `Your goal is to compose the body of an async JavaScript function.

--- a/packages/agents/src/agents/Scripter/prompts.ts
+++ b/packages/agents/src/agents/Scripter/prompts.ts
@@ -5,7 +5,7 @@ import { AgentPrompts } from "../../agents/utils";
 export const prompts: AgentPrompts<GoalRunArgs> = {
   name: "Scripter",
   expertise: `executing and creating scripts to solve basic tasks`,
-  initialMessages: ({ goal }: GoalRunArgs): ChatMessage[] => [
+  initialMessages: (): ChatMessage[] => [
     {
       role: "user",
       content: `Purpose:
@@ -24,6 +24,8 @@ When suitable scripts are found, you run them to solve the problem.
 If no scripts have been found, you cautiously consider createScript. You ensure any new script you create is specific, actionable, and not general.
 If a goal has been achieved or failed, you will call the agent_onGoalAchieved or agent_onGoalFailed function.`,
     },
+  ],
+  runMessages: ({ goal }: GoalRunArgs): ChatMessage[] => [
     {
       role: "user",
       content: goal,

--- a/packages/agents/src/agents/Synthesizer/prompts.ts
+++ b/packages/agents/src/agents/Synthesizer/prompts.ts
@@ -4,11 +4,13 @@ import { GoalRunArgs } from "../utils";
 export const prompts = {
   name: "Synthesizer",
   expertise: `Reads text files, analyzing and gathering data and information from text files, generating summaries and reports, and analyzing text.`,
-  initialMessages: ({ goal }: GoalRunArgs): ChatMessage[] => [
+  initialMessages: (): ChatMessage[] => [
     {
       role: "user",
       content: `You are a reader and synthesizer agent. Your job is to read text files, analyze text file contents`,
     },
+  ],
+  runMessages: ({ goal }: GoalRunArgs): ChatMessage[] => [
     {
       role: "user",
       content: goal,

--- a/packages/agents/src/agents/utils/Agent.ts
+++ b/packages/agents/src/agents/utils/Agent.ts
@@ -44,11 +44,6 @@ export class Agent<TRunArgs = GoalRunArgs> implements RunnableAgent<TRunArgs> {
   }
 
   public async *run(args: TRunArgs): AsyncGenerator<AgentOutput, RunResult, string | undefined> {
-    await this.init();
-    return yield* this.runWithExistingContext(args);
-  }
-
-  public async *runWithExistingContext(args: TRunArgs): AsyncGenerator<AgentOutput, RunResult, string | undefined> {
     await this.initRun(args);
   
     const { chat } = this.context;

--- a/packages/agents/src/agents/utils/AgentPrompts.ts
+++ b/packages/agents/src/agents/utils/AgentPrompts.ts
@@ -3,7 +3,8 @@ import { ChatMessage } from "@/agent-core";
 export interface AgentPrompts<TRunArgs> {
   name: string;
   expertise: string;
-  initialMessages: (runArguments: TRunArgs) => ChatMessage[];
+  initialMessages: () => ChatMessage[];
+  runMessages: (runArguments: TRunArgs) => ChatMessage[];
   loopPreventionPrompt: string;
   agentSpeakPrompt?: string;
 }

--- a/packages/agents/src/functions/OnGoalAchieved.ts
+++ b/packages/agents/src/functions/OnGoalAchieved.ts
@@ -1,4 +1,4 @@
-import { AgentOutputType } from "@/agent-core"
+import { AgentOutputType, ChatMessageBuilder } from "@/agent-core"
 import { ScriptFunction } from "./utils";
 import { Agent } from "../agents/utils";
 
@@ -35,7 +35,10 @@ export class OnGoalAchievedFunction extends ScriptFunction<OnGoalAchievedFuncPar
           content: params.message,
         },
       ],
-      messages: [],
+      messages: [
+        ChatMessageBuilder.functionCall(this.name, rawParams),
+        ChatMessageBuilder.functionCallResult(this.name, result),
+      ],
     };
   }
 
@@ -53,7 +56,13 @@ export class OnGoalAchievedFunction extends ScriptFunction<OnGoalAchievedFuncPar
           content: params.message,
         },
       ],
-      messages: [],
+      messages: [
+        ChatMessageBuilder.functionCall(this.name, rawParams),
+        ChatMessageBuilder.functionCallResult(
+          this.name,
+          `Failed calling ${this.name}:\n${error}`
+        ),
+      ],
     };
   }
 }

--- a/packages/agents/src/functions/OnGoalFailed.ts
+++ b/packages/agents/src/functions/OnGoalFailed.ts
@@ -1,4 +1,4 @@
-import { AgentOutputType } from "@/agent-core"
+import { AgentOutputType, ChatMessageBuilder } from "@/agent-core"
 import { ScriptFunction } from "./utils";
 import { Agent } from "../agents/utils";
 
@@ -35,7 +35,10 @@ export class OnGoalFailedFunction extends ScriptFunction<{}> {
           content: params.message,
         },
       ],
-      messages: [],
+      messages: [
+        ChatMessageBuilder.functionCall(this.name, rawParams),
+        ChatMessageBuilder.functionCallResult(this.name, result),
+      ],
     };
   }
 
@@ -53,7 +56,13 @@ export class OnGoalFailedFunction extends ScriptFunction<{}> {
           content: params.message,
         },
       ],
-      messages: [],
+      messages: [
+        ChatMessageBuilder.functionCall(this.name, rawParams),
+        ChatMessageBuilder.functionCallResult(
+          this.name,
+          `Failed calling ${this.name}:\n${error}`
+        ),
+      ],
     };
   }
 }


### PR DESCRIPTION
Evo now remembers the chat from the previous goal
Additionally, evo doesn't use quick termination by default (with gpt 3.5 prediction), instead evo is required to call onGoalAchieved. This was done because without it gpt 3.5 would try to exit evo in 2nd, and later goals. (Gpt 3.5 doesn't notice the second goal all the time)

In the future, we should consider not sorting the persistant messages at the top and instead sort by creation time. This should help gpt 3.5, but also prevent similar potential issues with gpt 4

This fix has not been applied to browser version to avoid conflicts with evo service, but can easily be done afterwards

Closes #497 