### PR TITLE
fix: properly handle chat id route transitions

### DIFF
--- a/apps/browser/app/page.tsx
+++ b/apps/browser/app/page.tsx
@@ -3,7 +3,7 @@
 import Chat from "@/components/Chat";
 import { evoServiceAtom, chatIdAtom } from "@/lib/store";
 import { EvoService } from "@/lib/services/evo/EvoService";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { useAtom } from "jotai";
@@ -13,9 +13,13 @@ function Dojo({ params }: { params: { id?: string } }) {
   const { status: sessionStatus, data: sessionData } = useSession();
   const [evoService, setEvoService] = useAtom(evoServiceAtom);
   const [, setChatId] = useAtom(chatIdAtom);
+  const [loading, setIsLoading] = useState(true);
 
   useEffect(() => {
     if (sessionStatus === "unauthenticated") {
+      if (params.id) {
+        router.push("/");
+      }
       setChatId("<anon>");
       return;
     }
@@ -27,6 +31,7 @@ function Dojo({ params }: { params: { id?: string } }) {
     if (sessionStatus === "loading") {
       return;
     }
+    setIsLoading(false);
 
     const user = sessionData?.user.email || "<anon>";
     if (evoService.user === user) {
@@ -38,15 +43,9 @@ function Dojo({ params }: { params: { id?: string } }) {
     setEvoService(new EvoService(user));
   }, [sessionStatus, sessionData]);
 
-  useEffect(() => {
-    if (sessionStatus === "unauthenticated" && params.id) {
-      router.push("/");
-    }
-  }, [sessionStatus, params.id]);
-
   return (
     <>
-      {sessionStatus !== "loading" ? (
+      {!loading ? (
         <Chat
           isAuthenticated={sessionStatus === "authenticated"}
           onCreateChat={(chatId: string) => {

--- a/apps/browser/lib/hooks/useEvoService.ts
+++ b/apps/browser/lib/hooks/useEvoService.ts
@@ -61,7 +61,7 @@ export const useEvoService = (
   // Helpers
   const updateUserFiles = useUpdateUserFiles();
 
-  const handleChatIdChange = (chatId: string | undefined) => {
+  const handleChatIdChange = async (chatId: string | undefined) => {
     const currentThread = evoService.current;
 
     if (currentThread && currentThread.chatId === chatId) {
@@ -91,7 +91,7 @@ export const useEvoService = (
         setError("Failed to start Evo.");
       },
     };
-    evoService.connect(config, callbacks);
+    await evoService.connect(config, callbacks);
   }
 
   const loadChatLog = async (chatId: string) => {
@@ -170,7 +170,7 @@ export const useEvoService = (
       if (!chatId) {
         chatId = uuid();
         await createChat(chatId);
-        handleChatIdChange(chatId);
+        await handleChatIdChange(chatId);
         onCreateChat(chatId);
       }
     }

--- a/apps/browser/lib/services/evo/EvoThread.ts
+++ b/apps/browser/lib/services/evo/EvoThread.ts
@@ -214,7 +214,6 @@ export class EvoThread {
       this._callbacks?.setWorkspace(this._state.workspace);
 
       if (response.done) {
-        console.log(response.value);
         const actionTitle = response.value.value.title;
         if (
           actionTitle.includes("onGoalAchieved") ||


### PR DESCRIPTION
This fixes the scenario where a user is logged in, and they try to load a specific `/chat/<id>` URL