### PR TITLE
chore: use llm model from context in predict next step

### DIFF
--- a/apps/browser/lib/api/ProxyLlmApi.ts
+++ b/apps/browser/lib/api/ProxyLlmApi.ts
@@ -1,4 +1,4 @@
-import { ChatLogs, LlmApi, LlmOptions } from "@evo-ninja/agents";
+import { ChatLogs, LlmApi, LlmModel, LlmOptions } from "@evo-ninja/agents";
 import { ChatCompletionMessage, ChatCompletionTool } from "openai/resources";
 import { ERROR_SUBSIDY_MAX } from "./errors";
 
@@ -9,7 +9,7 @@ export class ProxyLlmApi implements LlmApi {
   private _goalId: string | undefined = undefined;
 
   constructor(
-    private _defaultModel: string,
+    private _defaultModel: LlmModel,
     private _defaultMaxTokens: number,
     private _defaultMaxResponseTokens: number,
     private _setCapReached: () => void

--- a/packages/agents/src/agent-core/llm/LlmApi.ts
+++ b/packages/agents/src/agent-core/llm/LlmApi.ts
@@ -27,7 +27,7 @@ export interface LlmOptions {
 export interface LlmApi {
   getMaxContextTokens(): number;
   getMaxResponseTokens(): number;
-  getModel(): string;
+  getModel(): LlmModel;
   getResponse(
     chatLog: ChatLogs,
     functionDefinitions?: FunctionDefinition[],

--- a/packages/agents/src/agent-debug/DebugLlmApi.ts
+++ b/packages/agents/src/agent-debug/DebugLlmApi.ts
@@ -2,7 +2,7 @@ import { ChatCompletionMessage } from "openai/resources";
 import { DebugLog } from "./DebugLog";
 import { Timer } from "./Timer";
 
-import { LlmApi, LlmOptions, ChatLogs, ChatMessage } from "@/agent-core";
+import { LlmApi, LlmOptions, ChatLogs, LlmModel } from "@/agent-core";
 
 export class DebugLlmApi implements LlmApi {
   constructor(
@@ -18,7 +18,7 @@ export class DebugLlmApi implements LlmApi {
     return this.llm.getMaxResponseTokens();
   }
 
-  getModel(): string {
+  getModel(): LlmModel {
     return this.llm.getModel();
   }
 

--- a/packages/agents/src/agents/Evo/index.ts
+++ b/packages/agents/src/agents/Evo/index.ts
@@ -175,7 +175,7 @@ export class Evo extends Agent<GoalRunArgs> {
               : ""
           }`),
       {
-        model: "gpt-3.5-turbo-16k",
+        model: this.context.llm.getModel(),
       }
     );
   }


### PR DESCRIPTION
this PR aims to use the model defined in Evo configuration for the prediction step. In the future, we can add a model configuration (setting gpt-3.5, gpt-4, or gpt-4-turbo) in the UI and the entire execution would use the same model (guaranteeing consistency in max window context length & model performance)

closes #525 #603