### PR TITLE
Updates scrollbars to stable positioning

### DIFF
--- a/apps/browser/components/ChatLogs.tsx
+++ b/apps/browser/components/ChatLogs.tsx
@@ -67,7 +67,7 @@ export default function ChatLogs(props: ChatLogsProps) {
       <div
         ref={listContainerRef}
         onScroll={handleScroll}
-        className="w-full flex-1 items-center space-y-6 overflow-y-auto overflow-x-clip px-2 py-3 text-left"
+        className="w-full flex-1 items-center space-y-6 overflow-y-auto overflow-x-clip px-2 py-3 text-left [scrollbar-gutter:stable]"
       >
         {logs.map((msg, index, logs) => {
           const isEvo = msg.user === "evo";

--- a/apps/browser/components/Sidebar.tsx
+++ b/apps/browser/components/Sidebar.tsx
@@ -108,7 +108,7 @@ const Sidebar = ({
     if (activeChat !== chatId) {
       setActiveChat(chatId);
     }
-  }, [chatId, activeChat])
+  }, [chatId, activeChat]);
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
@@ -181,7 +181,7 @@ const Sidebar = ({
                     )}
                   </div>
                   {!isLoadingChats ? (
-                    <div className="h-full max-h-[30vh] space-y-0.5 overflow-y-auto">
+                    <div className="h-full max-h-[30vh] space-y-0.5 overflow-y-auto [scrollbar-gutter:stable]">
                       {chats && chats.length > 0 ? (
                         <div className="px-2">
                           {mappedChats?.map((chat) => (
@@ -212,7 +212,7 @@ const Sidebar = ({
                                         await handleEditClick(
                                           chat.id,
                                           e.currentTarget.value
-                                        )
+                                        );
                                       }
                                     }}
                                   />

--- a/apps/browser/components/Workspace.tsx
+++ b/apps/browser/components/Workspace.tsx
@@ -49,7 +49,7 @@ function Workspace({ onUpload }: WorkspaceProps) {
           )}
         </div>
       </div>
-      <div className="relative h-full max-h-[24vh] overflow-y-auto">
+      <div className="relative h-full max-h-[24vh] overflow-y-auto [scrollbar-gutter:stable]">
         {workspaceLoading ? (
           <div className="flex h-full w-full items-center justify-center">
             <div className="h-9 w-9 animate-spin rounded-full border-4 border-black/10 border-l-cyan-600" />
@@ -72,7 +72,7 @@ function Workspace({ onUpload }: WorkspaceProps) {
                 <div
                   {...getRootProps({
                     className: clsx(
-                      "dropzone group h-full space-y-1 overflow-y-auto rounded-lg border-2 border-solid border-zinc-900 p-[6px] transition-all duration-100 ease-in-out",
+                      "dropzone group h-full space-y-1 rounded-lg border-2 border-solid border-zinc-900 p-[6px] transition-all duration-100 ease-in-out",
                       {
                         "cursor-pointer !border-dashed !border-cyan-500 !bg-zinc-950":
                           isDragAccept,

--- a/apps/browser/components/modals/ModalBase.tsx
+++ b/apps/browser/components/modals/ModalBase.tsx
@@ -23,7 +23,7 @@ export default function Modal(props: PropsWithChildren<ModalProps>) {
           className={clsx(Ubuntu_FONT.className, "relative z-30")}
           onClose={onClose}
         >
-          <div className="fixed inset-0 overflow-y-auto bg-zinc-400/50 backdrop-blur">
+          <div className="fixed inset-0 overflow-y-auto bg-zinc-400/50 backdrop-blur [scrollbar-gutter:stable] ">
             <div className="flex min-h-full items-center justify-center text-center md:p-4">
               <Transition.Child
                 as={Fragment}
@@ -57,7 +57,7 @@ export default function Modal(props: PropsWithChildren<ModalProps>) {
                       />
                     </Button>
                   </div>
-                  <div className="max-h-[calc(100vh-64px)] space-y-8 overflow-y-auto bg-zinc-900 p-8 md:max-h-[calc(100vh-96px)]">
+                  <div className="max-h-[calc(100vh-64px)] space-y-8 overflow-y-auto bg-zinc-900 p-8 [scrollbar-gutter:stable] md:max-h-[calc(100vh-96px)]">
                     {children}
                   </div>
                 </Dialog.Panel>


### PR DESCRIPTION
Previously, the scrollbars would push the content over when appearing. Now, with the scrollbar-gutter: stable css, they are overlaid and don't affect the layout. This is especially helpful to avoid jankiness for modals that increase in size (like the upcoming details modal that grows in size as the user toggles views and the chat log adds new steps).