### PR TITLE
chore: add title to app in browser tab

### DIFF
--- a/apps/browser/app/layout.tsx
+++ b/apps/browser/app/layout.tsx
@@ -9,7 +9,12 @@ import "react-toastify/dist/ReactToastify.css";
 import SidebarLayout from "@/components/SidebarLayout";
 import { Providers } from "@/components/providers/Providers";
 import { cookies } from "next/headers";
+import { Metadata } from "next";
 config.autoAddCss = false;
+
+export const metadata: Metadata = {
+  title: "evo.ninja"
+}
 
 export default function EvoApp({ children }: { children: React.ReactNode }) {
   const currentDevice = cookies().get("X-User-Device");


### PR DESCRIPTION
this PR aims to show `evo.ninja` in the tab of the browser - right now it takes the route
![image](https://github.com/polywrap/evo.ninja/assets/21031138/c7788677-be0d-4abe-b49e-980cc3da1f6b)
