### PR TITLE
Multiple browser goals

### DIFF
--- a/apps/browser/lib/services/evo/createEvoInstance.ts
+++ b/apps/browser/lib/services/evo/createEvoInstance.ts
@@ -73,7 +73,6 @@ export function createEvoInstance(
     });
 
     if (openAiApiKey) {
-      console.log("Using OpenAI API");
       llm = new OpenAILlmApi(
         env.OPENAI_API_KEY,
         env.GPT_MODEL as LlmModel,
@@ -89,7 +88,6 @@ export function createEvoInstance(
         env.OPENAI_API_BASE_URL,
       );
     } else {
-      console.log("Using Evo API");
       const llmProxy = new ProxyLlmApi(
         env.GPT_MODEL as LlmModel,
         env.CONTEXT_WINDOW_TOKENS,

--- a/apps/browser/lib/services/evo/createEvoInstance.ts
+++ b/apps/browser/lib/services/evo/createEvoInstance.ts
@@ -32,11 +32,7 @@ export function createEvoInstance(
   onStatusUpdate: (status: string) => void,
   onGoalCapReached: () => void,
   onError: (error: string) => void
-): {
-  evo: Evo,
-  llm: LlmApi,
-  embedding: EmbeddingApi
-} | undefined {
+): Evo | undefined {
   let llm: LlmApi;
   let embedding: EmbeddingApi;
 
@@ -125,11 +121,7 @@ export function createEvoInstance(
         agentVariables
       )
     );
-    return {
-      evo,
-      llm,
-      embedding
-    };
+    return evo;
   } catch (e: any) {
     onError(e.message);
     return undefined;

--- a/packages/agents/src/agent-core/llm/chat/Chat.ts
+++ b/packages/agents/src/agent-core/llm/chat/Chat.ts
@@ -34,6 +34,16 @@ export class Chat {
 
   public async add(type: ChatLogType, msg: ChatMessage | ChatMessage[]): Promise<void> {
     const msgs = Array.isArray(msg) ? msg : [msg];
+    
+    this.addWithoutEvents(type, msgs);
+
+    if (this.options?.onMessagesAdded) {
+      await this.options.onMessagesAdded(type, msgs);
+    }
+  }
+
+  public addWithoutEvents(type: ChatLogType, msg: ChatMessage | ChatMessage[]) {
+    const msgs = Array.isArray(msg) ? msg : [msg];
 
     const msgsWithTokens = msgs.map((msg) => {
       const tokens = this._tokenizer.encode(JSON.stringify(msg)).length;
@@ -42,10 +52,6 @@ export class Chat {
     const tokens = msgsWithTokens.map(({ tokens }) => tokens);
 
     this._chatLogs.add(type, msgs, tokens)
-
-    if (this.options?.onMessagesAdded) {
-      await this.options.onMessagesAdded(type, msgs);
-    }
   }
 
   public async persistent(role: ChatRole, content: string): Promise<void>;


### PR DESCRIPTION
NOTE: requires https://github.com/polywrap/evo.ninja/pull/668 to be merged first

User can now use the same chat to accomplish multiple goals.
User can also go to old chats and continue with new goals.

Closes: #630 
The second sub-issues about changing openAI key on existing evo instances I reported here to be solved separately: https://github.com/polywrap/evo.ninja/issues/671