### PR TITLE
chore: redirect to agentcoin.org

### DIFF
--- a/apps/browser/vercel.json
+++ b/apps/browser/vercel.json
@@ -1,4 +1,11 @@
 {
+  "redirects": [
+    {
+      "source": "/(.*)",
+      "destination": "https://agentcoin.org",
+      "permanent": true
+    }
+  ],
   "functions": {
     "app/api/proxy/completions/route.ts": {
       "maxDuration": 45


### PR DESCRIPTION
Doing this redirect via vercel is required because squarespace domain redirects aren't working for domains that were migrated from google workspace via the acquisition of google domains.